### PR TITLE
Use debounce for all API responses. Use polling mechanism on FE load to deal with BE booting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ for a service account](https://cloud.google.com/sdk/gcloud/reference/auth/applic
  - Match overview including player availability
  - Training admin screen (add/change/remove trainings)
  - Match admin screen (add/change/remove matches)
- - Get back polling mechanism when back-end is still down.
+ - ~~Use polling mechanism when back-end is still down.~~
  - Ensure training endpoint are also protected
  - Use 'proper' authentication mechanism.
  
 ### Should have:
- - Debounce was introduced to ensure every API call takes at least 500 ms (for UX purposes). This only works if a call is successful. Should also work for unsuccessful ones.
+ - ~~Debounce was introduced to ensure every API call takes at least 500 ms (for UX purposes). This only works if a call is successful. Should also work for unsuccessful ones.~~
  - Github actions, used to deploy to Google cloud on every merge to master 
  - Stg env for testing purposes (use a different application version, but don't take all traffic ?)
  

--- a/src/main/react/src/utils/ApiClient.js
+++ b/src/main/react/src/utils/ApiClient.js
@@ -1,10 +1,13 @@
 import {fetchWithTimeout} from "./fetchWithTimeout";
 import {delay} from "./util";
 import {authenticationManager} from "./AuthenticationManager";
+import {InvalidSecretException} from "./Exceptions";
 
 
 const DEFAULT_TIMEOUT = 5000; //ms
-const DEFAULT_MIN_DELAY = 500; //ms
+const DEFAULT_MIN_DELAY = 750; //ms
+
+
 
 const _mergeFetchOptions = (options, secret) => ({
     ...options,
@@ -22,6 +25,7 @@ const _throwIfNotOk = (path, res) => {
         if (res.status === 403) {
             console.log("Status was 403");
             // setAuthenticated(false);
+            throw new InvalidSecretException("nope")
         }
 
         throw Error(
@@ -31,10 +35,10 @@ const _throwIfNotOk = (path, res) => {
 };
 
 
-const _resultWithMinDelay = (result, minDelay) =>
-    Promise.all([result, delay(minDelay)])
-        .then(([result, _]) => result);
-
+const _resultWithMinDelay =  async(result, minDelay) =>{
+    await delay(minDelay);
+    return result;
+};
 
 export const ApiClient = () => {
 

--- a/src/main/react/src/utils/AuthenticationApiClient.js
+++ b/src/main/react/src/utils/AuthenticationApiClient.js
@@ -1,4 +1,4 @@
-import {ApiClient} from "./apiClient";
+import {ApiClient} from "./ApiClient";
 
 const authenticationClient = ApiClient("auth");
 

--- a/src/main/react/src/utils/AuthenticationManager.js
+++ b/src/main/react/src/utils/AuthenticationManager.js
@@ -22,7 +22,6 @@ const getSecretFromLocalStorage = () =>{
 
   // Decrypt
   let cipher = item.toString();
-  // console.log(`Decrypting '${cipher}'`);
   let decrypt = Aes.decrypt(cipher, PRIVATE_ENCRYPTION_KEY);
   item = decrypt.toString(CryptoJS.enc.Utf8);
 
@@ -66,11 +65,8 @@ const authenticate = (passphrase) => {
 
     _authenticationCheck = new Promise((resolve) =>
         isAuthenticated
-            .then(() => true)
-            .catch(e => {
-                console.error("Something went wrong",e);
-                console.log(`typeOf ${typeof e}. instance of TimeoutError: ${e instanceof TimeoutError}`);
-             return false})
+            .then(_ => true)
+            .catch(_ => false)
             .then(it => {
                 _authenticated = it;
                 resolve(it)
@@ -92,15 +88,13 @@ const recursiveAuth = async (pass, number = 1) => {
     }
 
     try {
-        console.log(`trying to recursive auth ${number}`);
+        console.debug(`Trying to recursive auth ${number}`);
         await _doAuthenticate(pass)
     } catch (e) {
-        console.error("error",e);
-        // debugger;
         if (e instanceof TimeoutError) {
-            console.log("Catch ", number);
             await recursiveAuth(pass, ++number)
         } else {
+            console.debug("Unknown error occured", e);
             throw e;
         }
     }
@@ -110,7 +104,6 @@ const startupAuth = (passphrase) => {
     _authenticationCheck = new Promise((resolve) => {
         return recursiveAuth(passphrase)
             .then((result) => {
-                console.log(result);
                 _authenticated = true;
                 resolve(true)
             })

--- a/src/main/react/src/utils/BankApiClient.js
+++ b/src/main/react/src/utils/BankApiClient.js
@@ -1,4 +1,4 @@
-import {ApiClient} from "./apiClient";
+import {ApiClient} from "./ApiClient";
 
 const bankClient = ApiClient("bank");
 

--- a/src/main/react/src/utils/BankApiClient.js
+++ b/src/main/react/src/utils/BankApiClient.js
@@ -10,15 +10,6 @@ const getBalance = () => {
 const getTransactions = () => {
     return bankClient.call('bank/transactions')
         .then(data => internalize(data.transactions) || [])
-}
-const updateAttendee = (attendeeId, availability ) => {
-    return bankClient.callWithBody(`attendees/${attendeeId}`, {availability: availability},"PUT")
-        .then(data => {
-            return data.balance
-        })
-        .catch(e => {
-            console.error(e);
-        })
 };
 
 const internalize = transactions => {

--- a/src/main/react/src/utils/Exceptions.js
+++ b/src/main/react/src/utils/Exceptions.js
@@ -1,0 +1,16 @@
+
+export class InvalidSecretException extends Error {
+    constructor (...args) {
+        super(...args);
+        Error.captureStackTrace(this, TimeoutError)
+
+    }
+}
+
+export class TimeoutError extends Error {
+    constructor (...args) {
+        super(...args);
+        Error.captureStackTrace(this, TimeoutError)
+
+    }
+}

--- a/src/main/react/src/utils/TrainingsApiClient.js
+++ b/src/main/react/src/utils/TrainingsApiClient.js
@@ -1,4 +1,4 @@
-import {ApiClient} from "./apiClient";
+import {ApiClient} from "./ApiClient";
 
 const trainingsClient = ApiClient("trainings");
 
@@ -7,7 +7,7 @@ const getTrainings = (since, includeAttendees = true) => {
 };
 
 const updateAttendee = (attendeeId, availability ) => {
-    return trainingsClient.callWithBody(`attendees/${attendeeId}`, {availability: availability},{method:"PUT"})
+    return trainingsClient.callWithBody(`attendees/${attendeeId}`, {availability: availability},{method:"PUT"}, trainingsClient.defaultTimeout, 250 )
         .then(data => {
             return data
         })

--- a/src/main/react/src/utils/TrainingsApiClient.js
+++ b/src/main/react/src/utils/TrainingsApiClient.js
@@ -12,6 +12,7 @@ const updateAttendee = (attendeeId, availability ) => {
             return data
         })
         .catch(e => {
+            // TODO: Error handling
             console.error(e);
         })
 };

--- a/src/main/react/src/utils/fetchWithTimeout.js
+++ b/src/main/react/src/utils/fetchWithTimeout.js
@@ -1,3 +1,4 @@
+import {TimeoutError} from "./Exceptions";
 
 export const fetchWithTimeout = (uri, options = {}, time = 5000) => {
   // Lets set up our `AbortController`, and create a request options object
@@ -14,7 +15,7 @@ export const fetchWithTimeout = (uri, options = {}, time = 5000) => {
       // When we abort our `fetch`, the controller conveniently throws a named
       // error, allowing us to handle them separately from other errors.
       if (error.name === "AbortError") {
-        throw new Error("Response timed out");
+        throw new TimeoutError("Response timed out");
       }
       throw new Error(error.message);
     });


### PR DESCRIPTION
…to deal with BE booting

- Introduce custom errors (TimeoutError and InvalidSecretException) to deal  with API errors on a more functional level. e.g. TimeoutError is used to detect whether the back-end might be down and a retry is promising.
- Debounce API call always with 750ms, regardless of response. (better UX)
- Training API calls have a lower debounce for updating attendees, as that requires 2 subsequent API calls
- On startup, at most 10 tries are done to validate the authentication of a user. Until then, a loading spinner is shown.