### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
     "default:enableVulnerabilityAlerts",
     ":maintainLockFilesMonthly",
     ":dependencyDashboard",
-    "group:linters"
+    "group:linters",
+    "group:recommended"
   ],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
     "group:linters",
     "group:recommended"
   ],
+  "ignorePaths": [
+    "shaded-bunq-sdk/*"
+  ],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,10 @@
       "groupSlug": "dev-dependencies"
     },
     {
+      "matchPackagePatterns": ["^nl.jvandis"],
+      "excludePackagePatterns": ["^nl.jvandis" ]
+    },
+    {
       "matchPackageNames": ["@date-io/date-fns"],
       "allowedVersions": "< 2",
       "groupName": "Tightly coupled with material-ui/pickers v3",


### PR DESCRIPTION
* Renovate exclude all `nl.jvandis` dependencies
  * Quite aggressive but effective way
* Renovate add 'recommended' groups, which includes spring (boot)
* Renovate exclude shaded-bunq-sdk path from receiving renovate updates (as it's tightly coupled to bunq-sdk deps)