### PR TITLE
allow support roles to be visualised in the top x potters

### DIFF
--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -9,6 +9,11 @@ app:
         bunq-me-base-url: ${TOVO_HEREN_4_BUNQ_ME}
         tenant: tovo_heren_4
         title: "Tovo Heren 4"
+      - domain: localhost:8080
+        secret: ${API_SECRET_TOVO_HEREN_4}
+        bunq-me-base-url: ${TOVO_HEREN_4_BUNQ_ME}
+        tenant: tovo_heren_4
+        title: "Tovo Heren 4"
       - domain: 5.teambalance.local:8080
         secret: ${API_SECRET_TOVO_HEREN_5}
         bunq-me-base-url: ${TOVO_HEREN_5_BUNQ_ME}

--- a/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/BankObjects.kt
+++ b/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/BankObjects.kt
@@ -1,5 +1,6 @@
 package nl.jvandis.teambalance.api.bank
 
+import nl.jvandis.teambalance.api.users.Role
 import nl.jvandis.teambalance.api.users.User
 import java.time.ZonedDateTime
 
@@ -49,6 +50,7 @@ data class Potters(
 
 data class Potter(
     val name: String,
+    val role: Role,
     val transactions: List<Transaction>,
 )
 
@@ -63,6 +65,7 @@ data class PottersResponse(
 
 data class PotterResponse(
     val name: String,
+    val role: Role,
     val currency: String,
     val amount: Double,
 )

--- a/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterController.kt
+++ b/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterController.kt
@@ -39,13 +39,14 @@ class PotterController(
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
         sinceInput: LocalDateTime,
         @RequestParam(value = "include-inactive-users", defaultValue = "false") includeInactiveUsers: Boolean,
+        @RequestParam(value = "include-support-roles", defaultValue = "false") includeSupportRoles: Boolean,
     ): PottersResponse {
-        val pottersFullPeriod = potterService.getPotters(sinceInput.toZonedDateTime(), includeInactiveUsers)
+        val pottersFullPeriod = potterService.getPotters(sinceInput.toZonedDateTime(), includeInactiveUsers, includeSupportRoles)
         val now = ZonedDateTime.now()
         val pottersLastMonthResponse: PottersResponse? =
             if (Duration.between(sinceInput, now) > Duration.ofDays(30)) {
                 potterService
-                    .getPotters(now.minusDays(30), includeInactiveUsers)
+                    .getPotters(now.minusDays(30), includeInactiveUsers, includeSupportRoles)
                     .toPottersResponse(limit)
             } else {
                 null

--- a/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterController.kt
+++ b/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterController.kt
@@ -70,6 +70,7 @@ class PotterController(
         val cumulativeAmount = transactions.fold(0.0) { acc, cur -> acc + cur.amount.toDouble() }
         return PotterResponse(
             name = name,
+            role = role,
             currency = currency,
             amount = cumulativeAmount,
         )

--- a/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterService.kt
+++ b/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterService.kt
@@ -27,7 +27,7 @@ class PotterService(
                 .filter { includeInactiveUsers || it.isActive }
                 .map {
                     val transactions = groupedTransactions[it] ?: emptyList()
-                    Potter(it.name, transactions)
+                    Potter(it.name, it.role, transactions)
                 }
 
         return Potters(

--- a/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterService.kt
+++ b/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterService.kt
@@ -14,7 +14,7 @@ class PotterService(
     fun getPotters(
         since: ZonedDateTime,
         includeInactiveUsers: Boolean,
-        includeSupportRoles: Boolean
+        includeSupportRoles: Boolean,
     ): Potters {
         val relevantTransactions = getRelevantTransactions(since, includeSupportRoles)
         val groupedTransactions: Map<User, List<Transaction>> =
@@ -39,14 +39,16 @@ class PotterService(
         )
     }
 
-    private fun getRelevantTransactions(since: ZonedDateTime, includeSupportRoles: Boolean) =
-        bankService.getTransactions().transactions
-            .asSequence()
-            .filter { it.date > since }
-            .filter { it.type == TransactionType.DEBIT && it.currency == "€" }
-            .filter { it.user != null }
-            .filter { includeSupportRoles || !SUPPORT_TEAM_ROLES.contains(it.user?.role) }
-            .toList()
+    private fun getRelevantTransactions(
+        since: ZonedDateTime,
+        includeSupportRoles: Boolean,
+    ) = bankService.getTransactions().transactions
+        .asSequence()
+        .filter { it.date > since }
+        .filter { it.type == TransactionType.DEBIT && it.currency == "€" }
+        .filter { it.user != null }
+        .filter { includeSupportRoles || !SUPPORT_TEAM_ROLES.contains(it.user?.role) }
+        .toList()
 
     companion object {
         private val SUPPORT_TEAM_ROLES = setOf(Role.COACH, Role.TRAINER, Role.OTHER)

--- a/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterService.kt
+++ b/backend/src/main/kotlin/nl/jvandis/teambalance/api/bank/PotterService.kt
@@ -14,15 +14,16 @@ class PotterService(
     fun getPotters(
         since: ZonedDateTime,
         includeInactiveUsers: Boolean,
+        includeSupportRoles: Boolean
     ): Potters {
-        val relevantTransactions = getRelevantTransactions(since)
+        val relevantTransactions = getRelevantTransactions(since, includeSupportRoles)
         val groupedTransactions: Map<User, List<Transaction>> =
             relevantTransactions
                 .groupBy { x -> x.user!! }
 
         val potters: List<Potter> =
             userRepository.findAll()
-                .filter { !irrelevantTeamRoles.contains(it.role) }
+                .filter { includeSupportRoles || !SUPPORT_TEAM_ROLES.contains(it.role) }
                 .filter { includeInactiveUsers || it.isActive }
                 .map {
                     val transactions = groupedTransactions[it] ?: emptyList()
@@ -38,16 +39,16 @@ class PotterService(
         )
     }
 
-    private fun getRelevantTransactions(since: ZonedDateTime) =
+    private fun getRelevantTransactions(since: ZonedDateTime, includeSupportRoles: Boolean) =
         bankService.getTransactions().transactions
-            .filter {
-                it.date > since &&
-                    it.type == TransactionType.DEBIT &&
-                    it.currency == "€"
-            }
-            .filter { (it.user != null) && !irrelevantTeamRoles.contains(it.user.role) }
+            .asSequence()
+            .filter { it.date > since }
+            .filter { it.type == TransactionType.DEBIT && it.currency == "€" }
+            .filter { it.user != null }
+            .filter { includeSupportRoles || !SUPPORT_TEAM_ROLES.contains(it.user?.role) }
+            .toList()
 
     companion object {
-        private val irrelevantTeamRoles = setOf(Role.COACH, Role.TRAINER, Role.OTHER)
+        private val SUPPORT_TEAM_ROLES = setOf(Role.COACH, Role.TRAINER, Role.OTHER)
     }
 }

--- a/frontend/src/main/react/src/components/Potters.tsx
+++ b/frontend/src/main/react/src/components/Potters.tsx
@@ -15,9 +15,10 @@ interface SeasonPotters {
 export const Potters = (props: {
   refresh: boolean;
   limit?: number;
+  showSupportRoles?: boolean;
   showFloppers?: boolean;
 }) => {
-  const { limit = 3, showFloppers = true } = props;
+  const { limit = 3, showSupportRoles = false, showFloppers = true } = props;
   const [toppers, setToppers] = useState<SeasonPotters>({ season: [] });
   const [floppers, setFloppers] = useState<SeasonPotters>({ season: [] });
   const [isLoading, setIsLoading] = useState(false);
@@ -25,7 +26,7 @@ export const Potters = (props: {
 
   useEffect(() => {
     withLoading(setIsLoading, () =>
-      bankApiClient.getPotters(limit).then((it) => {
+      bankApiClient.getPotters(limit, showSupportRoles).then((it) => {
         setFloppers({ season: it.floppers, month: it.subPeriod?.floppers });
         setToppers({ season: it.toppers, month: it.subPeriod?.toppers });
       })

--- a/frontend/src/main/react/src/components/Potters.tsx
+++ b/frontend/src/main/react/src/components/Potters.tsx
@@ -5,7 +5,7 @@ import { withLoading } from "../utils/util";
 import Typography from "@mui/material/Typography";
 import { Grid } from "@mui/material";
 import Switch from "@mui/material/Switch";
-import { Potter } from "../utils/domain";
+import { Potter, roleMapper, SUPPORT_ROLES } from "../utils/domain";
 
 interface SeasonPotters {
   season: Potter[];
@@ -47,7 +47,14 @@ export const Potters = (props: {
           </Typography>
         </Grid>
         <Grid item xs={6}>
-          <Typography>{item.name}</Typography>
+          <Typography>
+            {item.name}{" "}
+            {SUPPORT_ROLES.includes(item.role) ? (
+              <em>(ℹ️️ {roleMapper[item.role]})</em>
+            ) : (
+              ""
+            )}
+          </Typography>
         </Grid>
       </Grid>
     );

--- a/frontend/src/main/react/src/components/Potters.tsx
+++ b/frontend/src/main/react/src/components/Potters.tsx
@@ -93,7 +93,7 @@ export const Potters = (props: {
         justifyContent="flex-end"
       >
         <Grid item>
-          <Typography variant="body1"> Month (last 30 days) </Typography>
+          <Typography variant="body1"> Maand (laatste 30 dagen) </Typography>
         </Grid>
         <Grid item>
           <Switch
@@ -103,7 +103,7 @@ export const Potters = (props: {
           />
         </Grid>
         <Grid item>
-          <Typography variant="body1"> Season </Typography>
+          <Typography variant="body1"> Seizoen </Typography>
         </Grid>
       </Grid>
 

--- a/frontend/src/main/react/src/utils/BankApiClient.tsx
+++ b/frontend/src/main/react/src/utils/BankApiClient.tsx
@@ -1,5 +1,5 @@
 import { ApiClient } from "./ApiClient";
-import { Potters, Transaction, TransactionType } from "./domain";
+import { Potters, Role, Transaction, TransactionType } from "./domain";
 
 const bankClient = ApiClient();
 
@@ -26,6 +26,7 @@ interface PottersResponse {
 
 interface PotterResponse {
   name: string;
+  role: Role;
   currency: string;
   amount: number;
 }
@@ -48,6 +49,10 @@ const getTransactions: (
   return internalize((data as TransactionsResponse).transactions) || [];
 };
 
+const internalizePotters = (response: PottersResponse) => ({
+  ...response,
+});
+
 const getPotters: (
   limit?: number,
   includeSupportRoles?: boolean
@@ -58,7 +63,9 @@ const getPotters: (
   let data = await bankClient.call(
     `bank/potters?limit=${limit}&include-support-roles=${includeSupportRoles}`
   );
-  return (data as PottersResponse) || { toppers: [], floppers: [] };
+  return internalizePotters(
+    (data as PottersResponse) || { toppers: [], floppers: [] }
+  );
 };
 
 const internalize: (transactions: TransactionResponse[]) => Transaction[] = (

--- a/frontend/src/main/react/src/utils/BankApiClient.tsx
+++ b/frontend/src/main/react/src/utils/BankApiClient.tsx
@@ -30,33 +30,35 @@ interface PotterResponse {
   amount: number;
 }
 
-const getBalance: () => Promise<string> = () => {
-  return bankClient
-    .call(`bank/balance`)
-    .then((data) => (data as any)?.balance || "€ XX,XX");
+const getBalance: () => Promise<string> = async () => {
+  let data = await bankClient.call(`bank/balance`);
+  return (await (data as any)?.balance) || "€ XX,XX";
 };
 
 const getTransactions: (
   limit?: number,
   offset?: number
-) => Promise<Transaction[]> = (limit: number = 20, offset: number = 0) => {
-  return bankClient
-    .call(`bank/transactions?limit=${limit}&offset=${offset}`)
-    .then(
-      (data: object) =>
-        internalize((data as TransactionsResponse).transactions) || []
-    );
+) => Promise<Transaction[]> = async (
+  limit: number = 20,
+  offset: number = 0
+) => {
+  const data = await bankClient.call(
+    `bank/transactions?limit=${limit}&offset=${offset}`
+  );
+  return internalize((data as TransactionsResponse).transactions) || [];
 };
 
-const getPotters: (limit?: number) => Promise<Potters> = (
-  limit: number = 3
+const getPotters: (
+  limit?: number,
+  includeSupportRoles?: boolean
+) => Promise<Potters> = async (
+  limit: number = 3,
+  includeSupportRoles: boolean = false
 ) => {
-  return bankClient
-    .call(`bank/potters?limit=${limit}`)
-    .then(
-      (data: object) =>
-        (data as PottersResponse) || { toppers: [], floppers: [] }
-    );
+  let data = await bankClient.call(
+    `bank/potters?limit=${limit}&include-support-roles=${includeSupportRoles}`
+  );
+  return (data as PottersResponse) || { toppers: [], floppers: [] };
 };
 
 const internalize: (transactions: TransactionResponse[]) => Transaction[] = (

--- a/frontend/src/main/react/src/utils/domain.tsx
+++ b/frontend/src/main/react/src/utils/domain.tsx
@@ -53,11 +53,12 @@ export type Role =
   | "OTHER";
 
 export const COACH_TRAINER_ROLES: Array<Role> = ["COACH", "TRAINER"];
+export const SUPPORT_ROLES: Array<Role> = [...COACH_TRAINER_ROLES, "OTHER"];
 export const roleMapper: Record<Role, string> = {
   COACH: "Coach",
   DIAGONAL: "Dia",
   MID: "Midden",
-  OTHER: "Trainingslid/vrije vogel",
+  OTHER: "Trainingslid",
   PASSER: "Passer/loper",
   SETTER: "Set-upper",
   LIBERO: "Libero",
@@ -83,6 +84,7 @@ export interface Potters {
 
 export interface Potter {
   name: string;
+  role: Role;
   currency: string;
   amount: number;
 }

--- a/frontend/src/main/react/src/views/TransactionsPage.tsx
+++ b/frontend/src/main/react/src/views/TransactionsPage.tsx
@@ -46,7 +46,7 @@ const TransactionsPage = (props: { refresh: boolean }) => {
         </Grid>
         <Grid container item xs={12}>
           <PageItem title="Potters">
-            <Potters refresh={props.refresh} limit={10} showFloppers={false} />
+            <Potters refresh={props.refresh} limit={20} showFloppers={false} />
           </PageItem>
         </Grid>
       </Grid>

--- a/frontend/src/main/react/src/views/TransactionsPage.tsx
+++ b/frontend/src/main/react/src/views/TransactionsPage.tsx
@@ -46,7 +46,12 @@ const TransactionsPage = (props: { refresh: boolean }) => {
         </Grid>
         <Grid container item xs={12}>
           <PageItem title="Potters">
-            <Potters refresh={props.refresh} limit={20} showFloppers={false} />
+            <Potters
+              refresh={props.refresh}
+              limit={20}
+              showFloppers={false}
+              showSupportRoles={true}
+            />
           </PageItem>
         </Grid>
       </Grid>


### PR DESCRIPTION
Adds the support roles to the transaction overview, allowing them to 'compete' in the topper / flopper tournament

<img width="705" alt="image" src="https://github.com/ZzAve/teambalance/assets/4041699/9b3f5b24-f0ee-416a-b213-62e291633536">
