### PR TITLE
Add structured logs for gcloud logging

### DIFF
--- a/.run/Application [LOCAL].run.xml
+++ b/.run/Application [LOCAL].run.xml
@@ -6,7 +6,7 @@
     <option name="SPRING_BOOT_MAIN_CLASS" value="nl.jvandis.teambalance.ApplicationKt" />
     <option name="VM_PARAMETERS" value="-Dliquibase.secureParsing=false" />
     <extension name="net.ashald.envfile">
-      <option name="IS_ENABLED" value="true" />
+      <option name="IS_ENABLED" value="false" />
       <option name="IS_SUBST" value="false" />
       <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
       <option name="IS_IGNORE_MISSING_FILES" value="false" />

--- a/README.md
+++ b/README.md
@@ -244,5 +244,9 @@ As with most projects, it's hardly ever considered finished.
 
 Unfortunately, Intellij doesn't understand shaded artifacts ([read up on it here](https://youtrack.jetbrains.com/issue/IDEA-126596))
 
-> A better workaround seems to be: Right-click on shade-bug-repackaged -> pom.xml in the project view in IntelliJ,
-> choose "Maven" -> "Ignore Projects". Then do a "Maven" -> "Reimport" on the top-level pom.xml.
+> A better workaround seems to be: 
+> 
+> - Right-click on shade-bug-repackaged -> pom.xml in the project view in IntelliJ,
+> - choose "Maven" -> "Ignore Projects". 
+> - Then do a "Maven" -> "Reload" on the top-level pom.xml.
+> .

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-logging-logback</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito.kotlin</groupId>
             <artifactId>mockito-kotlin</artifactId>
             <version>${mockito-kotlin.version}</version>

--- a/app/src/main/resources/application-cloud.yml
+++ b/app/src/main/resources/application-cloud.yml
@@ -26,3 +26,6 @@ app:
         bunq-me-base-url: ${TOVO_HEREN_5_BUNQ_ME}
         tenant: tovo_heren_5
         title: "Tovo Heren 5"
+
+logging:
+  config: classpath:logback-cloud.xml

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -62,16 +62,8 @@ spring:
       roles:
         - admin
         - user
-  cloud:
-    gcp:
-      project-id: "nope"
-      core:
-        enabled: false
-      secretmanager:
-        enabled: false
   liquibase:
     enabled: true
-
 
 logging:
   level:

--- a/app/src/main/resources/logback-cloud.xml
+++ b/app/src/main/resources/logback-cloud.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/default.xml"/>
+
+    <springProfile name="cloud">
+        <appender name="CLOUD" class="com.google.cloud.logging.logback.LoggingAppender">
+            <!-- Optional: filter logs at and above this level -->
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>INFO</level>
+            </filter>
+
+            <flushLevel>WARN</flushLevel>
+            <redirectToStdout>true</redirectToStdout>
+        </appender>
+
+        <root level="info">
+            <appender-ref ref="CLOUD"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,18 @@
         <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
         <mockito-kotlin.version>4.0.0</mockito-kotlin.version>
         <testcontainers.version>1.18.0</testcontainers.version>
+        <google-cloud-logging-logback.version>0.131.5-alpha</google-cloud-logging-logback.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-logging-logback</artifactId>
+                <version>${google-cloud-logging-logback.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Add Google's [java-logging-logback](https://github.com/googleapis/java-logging-logback) for structured logs in the gcloud console. This will allow for easier debugging and such.

```json
{
  "severity": "INFO",
  "time": "2024-05-04T09:53:00.271Z",
  "logging.googleapis.com/labels": {
    "loggerName": "nl.jvandis.teambalance.api.bank.BunqConfiguration$$SpringCGLIB$$0",
    "levelValue": "20000",
    "levelName": "INFO"
  },
  "logging.googleapis.com/trace_sampled": false,
  "message": "Setting up connection with bunq SANDBOX"
}
```

vs

```text
2024-05-04T11:56:52.841+02:00  INFO 17165 --- [onPool-worker-1] .t.a.b.BunqConfiguration$$SpringCGLIB$$0 : Setting up connection with bunq SANDBOX
```