### PR TITLE
fix(e2e): fix flaky e2e tests and improve CI performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ e2e:
 	(rm -rf ./e2e/playwright-report/index.html || true) && \
 		mkdir -p ./e2e/playwright-report && \
 		(echo "E2E tests are running ... " > ./e2e/playwright-report/index.html) && \
-		docker compose up $(if $(CI),,--build) --exit-code-from e2e
+		docker compose up --build --exit-code-from e2e --attach e2e
 
 e2e-report:
 	cd e2e && npm run report

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -20,7 +20,7 @@ FROM node:20-bookworm AS dev
 USER root
 WORKDIR /usr/src/app
 RUN npm install @playwright/test@1.59.1 && \
-  npx -y playwright@1.59.1 install --with-deps
+  npx -y playwright@1.59.1 install --with-deps chrome-for-testing firefox webkit
 
 COPY package.json package-lock.json ./
 COPY --from=base /tmp/node_modules ./node_modules

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -46,7 +46,9 @@ export default defineConfig({
     }
   },
 
-  /* Configure projects for major browsers */
+  /* Configure projects for major browsers.
+   * On CI only chromium runs to keep the pipeline fast (2 vCPU runner, serial
+   * workers). Firefox and webkit are available for local cross-browser checks. */
   projects: [
     // Setup project
     { name: "setup", testMatch: /.*\.setup\.ts/ },
@@ -60,23 +62,25 @@ export default defineConfig({
       dependencies: ["setup"],
     },
 
-    {
-      name: "firefox",
-      use: {
-        ...devices["Desktop Firefox"],
-        storageState: ".auth/user.json",
+    ...(!process.env.CI ? [
+      {
+        name: "firefox",
+        use: {
+          ...devices["Desktop Firefox"],
+          storageState: ".auth/user.json",
+        },
+        dependencies: ["setup"],
       },
-      dependencies: ["setup"],
-    },
 
-    {
-      name: "webkit",
-      use: {
-        ...devices["Desktop Safari"],
-        storageState: ".auth/user.json",
+      {
+        name: "webkit",
+        use: {
+          ...devices["Desktop Safari"],
+          storageState: ".auth/user.json",
+        },
+        dependencies: ["setup"],
       },
-      dependencies: ["setup"],
-    },
+    ] : []),
 
     /* Test against mobile viewports. */
     // {

--- a/e2e/src/playwright/tests/match-utils.ts
+++ b/e2e/src/playwright/tests/match-utils.ts
@@ -30,6 +30,9 @@ async function pickDateTime(page: Page, date: Date) {
   const combinedInput = dialog.getByRole("textbox");
   await combinedInput.waitFor({ state: "visible" });
   await combinedInput.click();
+  // Move to start of the masked input before typing — Playwright's click()
+  // lands in the centre of the element, leaving the cursor mid-string.
+  await page.keyboard.press("Home");
   await combinedInput.pressSequentially(digits);
 
   await dialog.getByRole("button", { name: "OK", exact: true }).click();

--- a/e2e/src/playwright/tests/previous-events.spec.ts
+++ b/e2e/src/playwright/tests/previous-events.spec.ts
@@ -1,11 +1,16 @@
 import { expect, test } from "@playwright/test";
 import { HOST, START_OF_SEASON } from "./utils";
 import { createTrainingEvent } from "./training-utils";
+import { v4 as uuid } from "uuid";
 
 test("Validate previous events can be shown", async ({ page }) => {
   await page.goto(HOST);
   await page.getByRole("button", { name: "Admin dingen" }).click();
-  await createTrainingEvent(page, "test", START_OF_SEASON);
+
+  // Use a unique comment so we can find THIS specific past event later,
+  // even when other tests have created training events in the database.
+  const comment = `past-${uuid().slice(0, 8)}`;
+  await createTrainingEvent(page, comment, START_OF_SEASON);
   await page.getByRole("button", { name: "Terug naar de veiligheid" }).click();
 
   await page.getByTestId("training-events").waitFor({ state: "visible" });
@@ -17,17 +22,25 @@ test("Validate previous events can be shown", async ({ page }) => {
     .click();
 
   await page.getByTestId("event-list").waitFor({ state: "visible" });
-  const eventListBefore = await page
-    .getByTestId("event-list-item")
-    .allInnerTexts();
 
-  await page.getByLabel("Oude events").check();
+  const oudeEvents = page.getByLabel("Oude events");
 
+  // Ensure the filter starts OFF — the checkbox may already be checked from
+  // a previous run or because it is the default state in this view.
+  await oudeEvents.uncheck();
   await page.getByTestId("event-list").waitFor({ state: "visible" });
-  const eventListAfter = await page
-    .getByTestId("event-list-item")
-    .allInnerTexts();
 
-  expect(eventListAfter).not.toBeFalsy();
-  expect(eventListBefore).not.toEqual(eventListAfter);
+  // The past event must NOT appear while old events are hidden.
+  await expect(
+    page.getByTestId("event-list-item").filter({ hasText: comment })
+  ).not.toBeVisible();
+
+  // Toggle old events ON.
+  await oudeEvents.check();
+  await page.getByTestId("event-list").waitFor({ state: "visible" });
+
+  // The past event must now be visible.
+  await expect(
+    page.getByTestId("event-list-item").filter({ hasText: comment })
+  ).toBeVisible();
 });

--- a/e2e/src/playwright/tests/training-utils.ts
+++ b/e2e/src/playwright/tests/training-utils.ts
@@ -39,6 +39,9 @@ async function pickDateTime(page: Page, date: Date) {
   const combinedInput = dialog.getByRole("textbox");
   await combinedInput.waitFor({ state: "visible" });
   await combinedInput.click();
+  // Move to start of the masked input before typing — Playwright's click()
+  // lands in the centre of the element, leaving the cursor mid-string.
+  await page.keyboard.press("Home");
   await combinedInput.pressSequentially(digits);
 
   // Confirm the selection

--- a/e2e/src/playwright/tests/training-utils.ts
+++ b/e2e/src/playwright/tests/training-utils.ts
@@ -4,42 +4,110 @@ import { addDays, ensure, NOW } from "./utils";
 /**
  * Pick a date+time in the MUI MobileDateTimePicker dialog.
  *
- * Strategy: open dialog → switch to text-input view (pen icon) →
- *           type date + time into the text fields → confirm with OK.
+ * Flow: open dialog → navigate to the right month → tap the day →
+ *       set hours → set minutes → confirm with OK.
  *
- * Previous approaches that used calendar month-navigation + gridcell clicking
- * broke because MUI renders duplicate day gridcells (overflow days from
- * adjacent months or transition animation artifacts). Using the text-input
- * view avoids all of that.
+ * The dialog is opened by clicking the read-only input labelled
+ * "Datum / tijd". All subsequent selectors target ARIA roles/labels
+ * inside the MUI dialog so they work across chromium, firefox and webkit.
  */
 async function pickDateTime(page: Page, date: Date) {
   // Open the MUI MobileDateTimePicker dialog by clicking the date input.
+  // The input has a dynamic accessible name like "Choose date, selected date is …".
   const dateInput = page.getByRole("textbox", { name: /Choose date/ });
   await dateInput.waitFor({ state: "visible" });
   await dateInput.click();
 
+  // --- DATE part ---
+  // The dialog shows a calendar. We need to navigate to the target month/year.
+  // MUI shows "month year" button in the calendar header (e.g. "april 2026").
+  // Strategy: click the left arrow button to go backward month-by-month until
+  // we reach the target month, or the right arrow to go forward.
   const dialog = page.getByRole("dialog");
   await dialog.waitFor({ state: "visible" });
 
-  // Switch to text-input view immediately. The button label is
-  // "calendar view is open, go to text input view" (or similar).
-  const textInputToggle = dialog.getByRole("button", {
-    name: /text input/i,
-  });
-  await textInputToggle.click();
+  // MUI renders navigation arrows as icon buttons. Use aria-label with a
+  // fallback to data-testid in case the label is not exposed.
+  const prevMonthBtn = dialog
+    .getByRole("button", { name: /Previous month/i })
+    .or(dialog.getByTestId("ArrowLeftIcon").locator(".."));
+  const nextMonthBtn = dialog
+    .getByRole("button", { name: /Next month/i })
+    .or(dialog.getByTestId("ArrowRightIcon").locator(".."));
 
-  // In text-input mode, MUI v5 renders ONE combined date-time input field.
-  // Format for nl locale with 24h time: dd-mm-yyyy hh:mm
-  const pad2 = (n: number) => String(n).padStart(2, "0");
+  // Dutch month names used by dayjs nl locale (lowercase)
+  const dutchMonths = [
+    "januari", "februari", "maart", "april", "mei", "juni",
+    "juli", "augustus", "september", "oktober", "november", "december",
+  ];
+  const targetLabel = `${dutchMonths[date.getMonth()]} ${date.getFullYear()}`;
 
-  // MUI's masked input auto-inserts separators when you type digits only.
-  const digits = `${pad2(date.getDate())}${pad2(date.getMonth() + 1)}${date.getFullYear()}${pad2(date.getHours())}${pad2(date.getMinutes())}`;
+  // Navigate month-by-month (max 24 iterations as safety net)
+  for (let i = 0; i < 24; i++) {
+    // The current month/year is shown as a button in the calendar header.
+    // MUI renders it inside a div with role "presentation", as a fade-transition span.
+    const headerText = await dialog
+      .locator(".MuiPickersCalendarHeader-label")
+      .textContent();
+    if (headerText?.trim().toLowerCase() === targetLabel) break;
 
-  // The single combined field — only one textbox exists in the dialog in keyboard mode.
-  const combinedInput = dialog.getByRole("textbox");
-  await combinedInput.waitFor({ state: "visible" });
-  await combinedInput.click();
-  await combinedInput.pressSequentially(digits);
+    // Determine direction: parse current header to compare
+    const currentMatch = headerText?.trim().toLowerCase();
+    const currentMonthIdx = dutchMonths.findIndex((m) => currentMatch?.startsWith(m));
+    const currentYear = parseInt(currentMatch?.split(" ").pop() ?? "0");
+    const currentTotal = currentYear * 12 + currentMonthIdx;
+    const targetTotal = date.getFullYear() * 12 + date.getMonth();
+
+    if (targetTotal < currentTotal) {
+      await prevMonthBtn.click();
+    } else {
+      await nextMonthBtn.click();
+    }
+    // Small wait for the calendar transition animation
+    await page.waitForTimeout(150);
+  }
+
+  // Click the target day button. MUI day buttons have role "gridcell" with
+  // the day number as text. Use exact match to avoid e.g. "1" matching "10".
+  await dialog
+    .getByRole("gridcell", { name: String(date.getDate()), exact: true })
+    .click();
+
+  // --- TIME part ---
+  // After picking a day, MUI transitions to the clock view (hours first).
+  // The clock is rendered as an SVG dial. Clicking hour/minute numbers
+  // on the dial is unreliable across browsers. Instead, MUI provides a
+  // text-input toggle: the pen/edit icon button switches to keyboard input.
+  // Wait a moment for the clock view to render.
+  await page.waitForTimeout(300);
+
+  // Click the pen/keyboard-input toggle to switch to text fields.
+  // MUI v5 renders this as a button with aria-label "open text input view"
+  // and an inner SVG with data-testid="PenIcon".
+  const penButton = dialog
+    .getByRole("button", { name: /text input/i })
+    .or(dialog.getByTestId("PenIcon").locator(".."));
+  if (await penButton.isVisible()) {
+    await penButton.click();
+  }
+
+  // Now the dialog shows two text inputs for hours and minutes.
+  const pad = (n: number) => String(n).padStart(2, "0");
+
+  // MUI labels the time inputs "hours" and "minutes"
+  const hoursInput = dialog.getByRole("textbox", { name: /hours/i }).or(
+    dialog.locator('input[aria-label="hours"]'),
+  );
+  const minutesInput = dialog.getByRole("textbox", { name: /minutes/i }).or(
+    dialog.locator('input[aria-label="minutes"]'),
+  );
+
+  if (await hoursInput.isVisible()) {
+    await hoursInput.click({ clickCount: 3 });
+    await hoursInput.pressSequentially(pad(date.getHours()));
+    await minutesInput.click({ clickCount: 3 });
+    await minutesInput.pressSequentially(pad(date.getMinutes()));
+  }
 
   // Confirm the selection
   await dialog.getByRole("button", { name: "OK", exact: true }).click();
@@ -55,22 +123,8 @@ export const createTrainingEvent = async (
 ) => {
   await page.getByRole("button", { name: "nieuwe training" }).click();
 
-  // Build the date string manually to avoid locale/OS differences across browsers.
-  // MUI MobileDateTimePicker input expects "dd-mm-yyyy hh:mm" (Dutch format).
-  const pad = (n: number) => String(n).padStart(2, "0");
-  const formattedDate =
-    [pad(date.getDate()), pad(date.getMonth() + 1), String(date.getFullYear())].join("-") +
-    " " +
-    [pad(date.getHours()), pad(date.getMinutes())].join(":");
-
-  // Click the input directly to avoid relying on MUI's dialog ARIA labels,
-  // which are not reliably exposed in webkit. Then type the value
-  // sequentially so the masked input registers each keystroke.
-  const dateInput = page.getByPlaceholder("dd-mm-yyyy hh:mm");
-  await dateInput.click();
-  await dateInput.pressSequentially(formattedDate, { delay: 50 });
-
-  await page.getByRole("button", { name: "OK", exact: true }).click();
+  // Use the MUI MobileDateTimePicker dialog to set the date.
+  await pickDateTime(page, date);
 
   await page.getByLabel("Locatie *").fill("Test locatie");
   await page.getByLabel("Opmerking").fill(comment);
@@ -85,12 +139,7 @@ export const createTrainingEvent = async (
   const matches = snackbarText?.match(/id ([a-f0-9-]+)/);
   const eventId = matches && matches[1];
 
-  // Dismiss the snackbar. The MUI Snackbar auto-hides and the button can
-  // become detached mid-click. Try clicking, but if it fails just wait for
-  // the snackbar to disappear on its own.
-  const alertDismiss = page.getByRole("alert").getByRole("button");
-  await alertDismiss.click({ timeout: 3000 }).catch(() => {});
-  await page.getByRole("alert").waitFor({ state: "hidden", timeout: 10000 }).catch(() => {});
+  await page.getByRole("alert").getByRole("button").click();
   return ensure(eventId, "event training Id");
 };
 
@@ -104,8 +153,7 @@ export async function updateTraining(page: Page, eventId: string) {
   await expect(page.getByRole("alert")).toContainText(
     `Training event (id ${eventId}) geüpdate`,
   );
-  await page.getByRole("alert").getByRole("button").click({ timeout: 3000 }).catch(() => {});
-  await page.getByRole("alert").waitFor({ state: "hidden", timeout: 10000 }).catch(() => {});
+  await page.getByRole("alert").getByRole("button").click();
 }
 
 export async function deleteTraining(page: Page, eventId: string | void) {

--- a/e2e/src/playwright/tests/training-utils.ts
+++ b/e2e/src/playwright/tests/training-utils.ts
@@ -28,34 +28,18 @@ async function pickDateTime(page: Page, date: Date) {
   });
   await textInputToggle.click();
 
-  // In text-input mode, MUI renders a single date text field (dd/mm/yyyy
-  // format for nl locale) and two fields for hours and minutes.
-  // The date field is labelled "Datum / tijd" and uses the format dd/mm/yyyy.
+  // In text-input mode, MUI v5 renders ONE combined date-time input field.
+  // Format for nl locale with 24h time: dd-mm-yyyy hh:mm
   const pad2 = (n: number) => String(n).padStart(2, "0");
-  const dateStr = `${pad2(date.getDate())}/${pad2(date.getMonth() + 1)}/${date.getFullYear()}`;
 
-  // The date text input — MUI renders it with the accessible name matching
-  // the label "Datum / tijd" (same label as the outer input).
-  const dateField = dialog.locator('input[placeholder="dd/mm/yyyy"]').or(
-    dialog.getByRole("textbox", { name: /datum/i }),
-  );
-  await dateField.waitFor({ state: "visible" });
-  // Triple-click to select all, then type the new date
-  await dateField.click({ clickCount: 3 });
-  await dateField.pressSequentially(dateStr);
+  // MUI's masked input auto-inserts separators when you type digits only.
+  const digits = `${pad2(date.getDate())}${pad2(date.getMonth() + 1)}${date.getFullYear()}${pad2(date.getHours())}${pad2(date.getMinutes())}`;
 
-  // Hours and minutes fields
-  const hoursInput = dialog.getByRole("textbox", { name: /hours/i }).or(
-    dialog.locator('input[aria-label="hours"]'),
-  );
-  const minutesInput = dialog.getByRole("textbox", { name: /minutes/i }).or(
-    dialog.locator('input[aria-label="minutes"]'),
-  );
-
-  await hoursInput.click({ clickCount: 3 });
-  await hoursInput.pressSequentially(pad2(date.getHours()));
-  await minutesInput.click({ clickCount: 3 });
-  await minutesInput.pressSequentially(pad2(date.getMinutes()));
+  // The single combined field — only one textbox exists in the dialog in keyboard mode.
+  const combinedInput = dialog.getByRole("textbox");
+  await combinedInput.waitFor({ state: "visible" });
+  await combinedInput.click();
+  await combinedInput.pressSequentially(digits);
 
   // Confirm the selection
   await dialog.getByRole("button", { name: "OK", exact: true }).click();

--- a/e2e/src/playwright/tests/training-utils.ts
+++ b/e2e/src/playwright/tests/training-utils.ts
@@ -4,97 +4,47 @@ import { addDays, ensure, NOW } from "./utils";
 /**
  * Pick a date+time in the MUI MobileDateTimePicker dialog.
  *
- * Flow: open dialog → navigate to the right month → tap the day →
- *       set hours → set minutes → confirm with OK.
+ * Strategy: open dialog → switch to text-input view (pen icon) →
+ *           type date + time into the text fields → confirm with OK.
  *
- * The dialog is opened by clicking the read-only input labelled
- * "Datum / tijd". All subsequent selectors target ARIA roles/labels
- * inside the MUI dialog so they work across chromium, firefox and webkit.
+ * Previous approaches that used calendar month-navigation + gridcell clicking
+ * broke because MUI renders duplicate day gridcells (overflow days from
+ * adjacent months or transition animation artifacts). Using the text-input
+ * view avoids all of that.
  */
 async function pickDateTime(page: Page, date: Date) {
   // Open the MUI MobileDateTimePicker dialog by clicking the date input.
-  // The input has a dynamic accessible name like "Choose date, selected date is …".
   const dateInput = page.getByRole("textbox", { name: /Choose date/ });
   await dateInput.waitFor({ state: "visible" });
   await dateInput.click();
 
-  // --- DATE part ---
-  // The dialog shows a calendar. We need to navigate to the target month/year.
-  // MUI shows "month year" button in the calendar header (e.g. "april 2026").
-  // Strategy: click the left arrow button to go backward month-by-month until
-  // we reach the target month, or the right arrow to go forward.
   const dialog = page.getByRole("dialog");
   await dialog.waitFor({ state: "visible" });
 
-  // MUI renders navigation arrows as icon buttons. Use aria-label with a
-  // fallback to data-testid in case the label is not exposed.
-  const prevMonthBtn = dialog
-    .getByRole("button", { name: /Previous month/i })
-    .or(dialog.getByTestId("ArrowLeftIcon").locator(".."));
-  const nextMonthBtn = dialog
-    .getByRole("button", { name: /Next month/i })
-    .or(dialog.getByTestId("ArrowRightIcon").locator(".."));
+  // Switch to text-input view immediately. The button label is
+  // "calendar view is open, go to text input view" (or similar).
+  const textInputToggle = dialog.getByRole("button", {
+    name: /text input/i,
+  });
+  await textInputToggle.click();
 
-  // Dutch month names used by dayjs nl locale (lowercase)
-  const dutchMonths = [
-    "januari", "februari", "maart", "april", "mei", "juni",
-    "juli", "augustus", "september", "oktober", "november", "december",
-  ];
-  const targetLabel = `${dutchMonths[date.getMonth()]} ${date.getFullYear()}`;
+  // In text-input mode, MUI renders a single date text field (dd/mm/yyyy
+  // format for nl locale) and two fields for hours and minutes.
+  // The date field is labelled "Datum / tijd" and uses the format dd/mm/yyyy.
+  const pad2 = (n: number) => String(n).padStart(2, "0");
+  const dateStr = `${pad2(date.getDate())}/${pad2(date.getMonth() + 1)}/${date.getFullYear()}`;
 
-  // Navigate month-by-month (max 24 iterations as safety net)
-  for (let i = 0; i < 24; i++) {
-    // The current month/year is shown as a button in the calendar header.
-    // MUI renders it inside a div with role "presentation", as a fade-transition span.
-    const headerText = await dialog
-      .locator(".MuiPickersCalendarHeader-label")
-      .textContent();
-    if (headerText?.trim().toLowerCase() === targetLabel) break;
+  // The date text input — MUI renders it with the accessible name matching
+  // the label "Datum / tijd" (same label as the outer input).
+  const dateField = dialog.locator('input[placeholder="dd/mm/yyyy"]').or(
+    dialog.getByRole("textbox", { name: /datum/i }),
+  );
+  await dateField.waitFor({ state: "visible" });
+  // Triple-click to select all, then type the new date
+  await dateField.click({ clickCount: 3 });
+  await dateField.pressSequentially(dateStr);
 
-    // Determine direction: parse current header to compare
-    const currentMatch = headerText?.trim().toLowerCase();
-    const currentMonthIdx = dutchMonths.findIndex((m) => currentMatch?.startsWith(m));
-    const currentYear = parseInt(currentMatch?.split(" ").pop() ?? "0");
-    const currentTotal = currentYear * 12 + currentMonthIdx;
-    const targetTotal = date.getFullYear() * 12 + date.getMonth();
-
-    if (targetTotal < currentTotal) {
-      await prevMonthBtn.click();
-    } else {
-      await nextMonthBtn.click();
-    }
-    // Small wait for the calendar transition animation
-    await page.waitForTimeout(150);
-  }
-
-  // Click the target day button. MUI day buttons have role "gridcell" with
-  // the day number as text. Use exact match to avoid e.g. "1" matching "10".
-  await dialog
-    .getByRole("gridcell", { name: String(date.getDate()), exact: true })
-    .click();
-
-  // --- TIME part ---
-  // After picking a day, MUI transitions to the clock view (hours first).
-  // The clock is rendered as an SVG dial. Clicking hour/minute numbers
-  // on the dial is unreliable across browsers. Instead, MUI provides a
-  // text-input toggle: the pen/edit icon button switches to keyboard input.
-  // Wait a moment for the clock view to render.
-  await page.waitForTimeout(300);
-
-  // Click the pen/keyboard-input toggle to switch to text fields.
-  // MUI v5 renders this as a button with aria-label "open text input view"
-  // and an inner SVG with data-testid="PenIcon".
-  const penButton = dialog
-    .getByRole("button", { name: /text input/i })
-    .or(dialog.getByTestId("PenIcon").locator(".."));
-  if (await penButton.isVisible()) {
-    await penButton.click();
-  }
-
-  // Now the dialog shows two text inputs for hours and minutes.
-  const pad = (n: number) => String(n).padStart(2, "0");
-
-  // MUI labels the time inputs "hours" and "minutes"
+  // Hours and minutes fields
   const hoursInput = dialog.getByRole("textbox", { name: /hours/i }).or(
     dialog.locator('input[aria-label="hours"]'),
   );
@@ -102,12 +52,10 @@ async function pickDateTime(page: Page, date: Date) {
     dialog.locator('input[aria-label="minutes"]'),
   );
 
-  if (await hoursInput.isVisible()) {
-    await hoursInput.click({ clickCount: 3 });
-    await hoursInput.pressSequentially(pad(date.getHours()));
-    await minutesInput.click({ clickCount: 3 });
-    await minutesInput.pressSequentially(pad(date.getMinutes()));
-  }
+  await hoursInput.click({ clickCount: 3 });
+  await hoursInput.pressSequentially(pad2(date.getHours()));
+  await minutesInput.click({ clickCount: 3 });
+  await minutesInput.pressSequentially(pad2(date.getMinutes()));
 
   // Confirm the selection
   await dialog.getByRole("button", { name: "OK", exact: true }).click();
@@ -139,7 +87,12 @@ export const createTrainingEvent = async (
   const matches = snackbarText?.match(/id ([a-f0-9-]+)/);
   const eventId = matches && matches[1];
 
-  await page.getByRole("alert").getByRole("button").click();
+  // Dismiss the snackbar. The MUI Snackbar auto-hides and the button can
+  // become detached mid-click. Try clicking, but if it fails just wait for
+  // the snackbar to disappear on its own.
+  const alertDismiss = page.getByRole("alert").getByRole("button");
+  await alertDismiss.click({ timeout: 3000 }).catch(() => {});
+  await page.getByRole("alert").waitFor({ state: "hidden", timeout: 10000 }).catch(() => {});
   return ensure(eventId, "event training Id");
 };
 
@@ -153,7 +106,8 @@ export async function updateTraining(page: Page, eventId: string) {
   await expect(page.getByRole("alert")).toContainText(
     `Training event (id ${eventId}) geüpdate`,
   );
-  await page.getByRole("alert").getByRole("button").click();
+  await page.getByRole("alert").getByRole("button").click({ timeout: 3000 }).catch(() => {});
+  await page.getByRole("alert").waitFor({ state: "hidden", timeout: 10000 }).catch(() => {});
 }
 
 export async function deleteTraining(page: Page, eventId: string | void) {

--- a/e2e/src/playwright/tests/training-utils.ts
+++ b/e2e/src/playwright/tests/training-utils.ts
@@ -55,8 +55,22 @@ export const createTrainingEvent = async (
 ) => {
   await page.getByRole("button", { name: "nieuwe training" }).click();
 
-  // Use the MUI MobileDateTimePicker dialog to set the date.
-  await pickDateTime(page, date);
+  // Build the date string manually to avoid locale/OS differences across browsers.
+  // MUI MobileDateTimePicker input expects "dd-mm-yyyy hh:mm" (Dutch format).
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const formattedDate =
+    [pad(date.getDate()), pad(date.getMonth() + 1), String(date.getFullYear())].join("-") +
+    " " +
+    [pad(date.getHours()), pad(date.getMinutes())].join(":");
+
+  // Click the input directly to avoid relying on MUI's dialog ARIA labels,
+  // which are not reliably exposed in webkit. Then type the value
+  // sequentially so the masked input registers each keystroke.
+  const dateInput = page.getByPlaceholder("dd-mm-yyyy hh:mm");
+  await dateInput.click();
+  await dateInput.pressSequentially(formattedDate, { delay: 50 });
+
+  await page.getByRole("button", { name: "OK", exact: true }).click();
 
   await page.getByLabel("Locatie *").fill("Test locatie");
   await page.getByLabel("Opmerking").fill(comment);


### PR DESCRIPTION
## Summary

- Fix MUI date picker entering digits at wrong cursor position (Playwright `click()` lands centre of input, not start) — caused events to be created at wrong date/time
- Fix `previous-events` test: use unique UUID comment, establish known filter state, assert specific event visibility rather than comparing full lists
- Run only chromium on CI (was running chromium + firefox + webkit serially on a 2-vCPU runner — ~3× slower for no real benefit)
- Use `chrome-for-testing` browser in Docker image
- Suppress backend/frontend/postgres log noise during `make e2e` with `--attach e2e`
- Increase `expect.timeout` 15s→30s and test `timeout` 60s→90s to handle slow CI data loading
- Add match CRUD e2e tests (`crud-matches.spec.ts`, `match-utils.ts`)

## Test plan

- [x] All 9 tests pass locally (`make e2e`)
- [x] `previous-events` test now correctly verifies a specific past event appears after toggling "Oude events"
- [x] Date picker tested with past date (START_OF_SEASON = Sept 1 2025) — event created at correct date
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date-time input cursor placement in automated tests.

* **Tests**
  * Improved end-to-end tests for more reliable event visibility checks and unique test data to avoid flakiness.
  * Adjusted test setup to ensure all browser targets are available locally while trimming non-chromium projects on CI.

* **Chores**
  * Test runner now always rebuilds and attaches e2e output for consistent diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->