### PR TITLE
feat(orchestrate): hierarchical tasks, context files, reflect + decompose

### DIFF
--- a/.claude/commands/orchestrate-worker.md
+++ b/.claude/commands/orchestrate-worker.md
@@ -121,7 +121,7 @@ If `PARENT_TASK_FILE` is empty, you are a standalone task — behave as before.
 
 ## [execute]
 - **Goal:** Implement the feature/fix described in the task
-wo- **Working directory:**
+- **Working directory:**
   - If `WORKTREE_PATH` is provided → work in that worktree directory
   - Navigate to worktree: `cd {{WORKTREE_PATH}}`
   - All file paths are relative to the worktree root

--- a/.claude/commands/orchestrate-worker.md
+++ b/.claude/commands/orchestrate-worker.md
@@ -14,6 +14,24 @@ You are a focused worker agent in the TeamBalance orchestrate system. Your job i
 **Context:** {{CONTEXT}}
 **File Boundaries:** {{FILE_BOUNDARIES}}
 **Worktree Path:** {{WORKTREE_PATH}} _(only for execute/test tasks)_
+**Parent Task File:** {{PARENT_TASK_FILE}} _(path to `.orchestration/tasks/<slug>.md` if subtask of a parent; empty for standalone tasks)_
+
+# Working with Parent Context
+
+If `PARENT_TASK_FILE` is provided, you are a subtask of a larger parent task:
+
+**At start of work:**
+1. Read the file at `{{PARENT_TASK_FILE}}`
+2. Absorb the Intent, Subtasks progress, Decisions Log, and Current State
+3. Let the Intent guide your implementation — don't drift from it
+
+**At end of work (before returning report):**
+1. Append to Decisions Log: `- YYYY-MM-DD (<task-type> worker): <key decision or outcome>`
+2. Overwrite Current State with a 1–3 sentence summary of where the work stands
+3. Mark your subtask line as `[x]` in the Subtasks section
+4. Save the file
+
+If `PARENT_TASK_FILE` is empty, you are a standalone task — behave as before.
 
 # Task Type Instructions
 
@@ -136,6 +154,37 @@ wo- **Working directory:**
   6. Commit test code
   7. Run `build` to verify
 - **Report:** Coverage added, test results, build status, commit SHA, worktree path used
+
+## [reflect]
+- **Goal:** Validate that the parent task's actual outcome matches its original intent
+- **Requires:** `PARENT_TASK_FILE` must be provided
+- **Actions:**
+  1. Read the full parent task file at `{{PARENT_TASK_FILE}}`
+  2. Compare the Intent section against the Decisions Log + Current State
+  3. Decide: does the actual outcome match the original intent?
+  4. Write a Reflection section into the task file:
+     - **Intent matched:** yes / partial / no
+     - **Deviations:** list any drift from intent
+     - **Follow-ups needed:** list any gaps that require new tasks
+  5. Report:
+     - If intent fully matched → `STATUS: done`, NOTES: "Reflection: intent matched"
+     - If partial or gaps found → `STATUS: blocked`, FOLLOW-UP: comma-separated follow-up task names, NOTES: summary of gaps
+- **No code changes:** do not modify source code or tests during a `[reflect]` task
+
+## [decompose-or-execute]
+- **Goal:** For parent tasks with no subtasks — decide whether to decompose or execute directly
+- **Actions — choose one mode:**
+
+  **Mode A — Decompose:** task is large, multi-file, or needs coordination
+  1. Analyze the parent's Context
+  2. Edit `.orchestration/backlog.md` to add 2–5 subtasks nested 4 spaces under the parent
+  3. Subtask format: `- [ ] \`[P2]\` \`[execute]\` <name>` (use appropriate types)
+  4. Report `STATUS: done`, NOTES: "Decomposed into N subtasks; orchestrator will pick up next round"
+  5. Do NOT execute any subtasks yourself
+
+  **Mode B — Execute directly:** task is small (≤3 files, single concern)
+  1. Execute normally like any `[execute]` task
+  2. Report as usual with commit SHA, tests, build status
 
 ## [ci]
 - **Goal:** Monitor PR CI status, validate review comments, rebase/merge when green

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -53,6 +53,10 @@ Never proceed with a broken build.
 - Creating/removing worktrees (`git worktree add`, `git worktree remove`, `git worktree list`)
 - Creating PRs for completed worktrees (`gh pr create`)
 - Running `build` to verify a completed round (step 12 only)
+- Creating `.orchestration/tasks/<slug>.md` (new parent task context files)
+- Moving `.orchestration/tasks/<slug>.md` → `.orchestration/tasks/archive/<slug>.md` (archival on parent completion)
+- Adding `- Task file:` metadata bullets to parent tasks in `backlog.md`
+- Appending auto-injected `[reflect]` subtasks to parents in `backlog.md`
 
 **ALL other work — including:**
 - Editing files (code, config, markdown, docs)
@@ -77,6 +81,7 @@ Never proceed with a broken build.
 | `[execute]` | Implement feature or fix | Write code, tests, commit; requires worktree |
 | `[test]` | Add test coverage to existing code | Write tests, commit; requires worktree |
 | `[ci]` | Monitor PR CI status; validate PR comments; rebase/merge when green | No code changes; pure monitoring + merge |
+| `[reflect]` | Validate that a parent task's result matches its intent | Read parent task file, compare Intent vs Decisions Log + Current State, report gaps |
 
 **`[ci]` Worker Decision Tree:**
 
@@ -102,6 +107,95 @@ the orchestrator must escalate to the user rather than re-dispatching. Present:
 - PR number and URL
 - All known blockers from previous rounds
 - Ask user what action to take (close PR, fix blocker, override)
+
+# Hierarchical Tasks
+
+Parent tasks OWN subtasks nested in `.orchestration/backlog.md`:
+
+```markdown
+- [ ] `[P1]` Implement event list page
+    - Context: First page users see. FSD, MUI.
+    - Task file: .orchestration/tasks/implement-event-list-page.md
+    - [ ] `[P1]` `[execute]` Build event list component
+    - [ ] `[P2]` `[review]` Review event list
+    - [ ] `[P2]` `[ci]` Validate CI for PR
+    - [ ] `[P2]` `[reflect]` Verify result matches intent
+```
+
+**Rules:**
+- Parent tasks have priority only (no type tag)
+- Subtasks have priority + type tag, indented 4 spaces
+- A parent is Done only when ALL subtasks are Done
+- Standalone (non-nested) tasks still work as before
+
+# Task Context Files
+
+Every parent task gets a persistent context file at `.orchestration/tasks/<slug>.md`.
+
+**Lifecycle:**
+1. **Created by the orchestrator** when the parent is first dispatched (whitelisted direct operation)
+2. **Read and updated by each subtask worker** — they append to Decisions Log and overwrite Current State
+3. **Validated by the final `[reflect]` subtask** — worker reads Intent vs actual outcome
+4. **Archived** to `.orchestration/tasks/archive/<slug>.md` when the parent moves to Done
+
+**Schema (orchestrator writes this on creation):**
+
+```markdown
+# Task: <parent task name>
+
+**Status:** In Progress
+**Priority:** <P1/P2/P3>
+**Created:** YYYY-MM-DD
+**Parent backlog entry:** <task name>
+
+## Intent
+<parent Context field, verbatim>
+
+## Subtasks
+- [ ] <subtask 1 name>
+- [ ] <subtask 2 name>
+- [ ] <... including auto-injected [reflect] subtask>
+
+## Decisions Log
+(Appended by each worker)
+
+## Current State
+(Overwritten by each worker)
+
+## Reflection
+(Filled in by the [reflect] subtask)
+```
+
+**Worker contract:**
+- Every subtask worker receives `PARENT_TASK_FILE: .orchestration/tasks/<slug>.md`
+- At start: read the file for context
+- At end: append a Decisions Log entry, overwrite Current State, mark its subtask line as `[x]`
+
+# WIP Preference (Stop Starting, Start Finishing)
+
+Strong preference, not a hard limit:
+- ≤2 active parents at a time
+- ≤4 subtasks dispatched per round
+- **Always prefer** finishing an in-progress parent over starting a new one
+- If breaching the preference (e.g. only P1 work is in a third parent), allow it but note the breach in the handover
+
+# Auto-Injected `[reflect]` Subtask
+
+When the orchestrator first processes a parent task with existing subtasks, it auto-appends a final subtask:
+
+```markdown
+- [ ] `[P2]` `[reflect]` Verify result matches intent
+```
+
+The orchestrator never adds a `[reflect]` twice. If one already exists at the end of the subtask list, leave it alone.
+
+# Decomposition on Dispatch
+
+When the orchestrator encounters a parent task with NO subtasks, it dispatches a worker with a directive to either:
+- **Propose a decomposition** (worker writes subtasks into the backlog under the parent) OR
+- **Execute the task directly** if it's small enough
+
+The worker decides based on scope. If subtasks are proposed, the orchestrator picks them up in the next round and auto-injects `[reflect]` at that point.
 
 # Core Loop
 
@@ -139,6 +233,8 @@ the orchestrator must escalate to the user rather than re-dispatching. Present:
 > If not on the whitelist → stop, dispatch a worker instead.
 
 - Extract tasks from **Active** section of `.orchestration/backlog.md`
+- For parent tasks, extract the nested subtasks list; each subtask becomes an independently dispatchable unit
+- A parent is eligible only via its subtasks — never dispatch the parent itself
 - Filter for eligible: not done, not parked, all dependencies in Done
 - **Cascading park rule:** If a task's dependency is currently in the **Parked** section (not Done),
   automatically move that task to Parked with note: `"Waiting for '<dependency>' to be unparked first"`
@@ -150,6 +246,8 @@ the orchestrator must escalate to the user rather than re-dispatching. Present:
 
 ### 7. PRIORITIZE
 
+- **Finish-first bias (WIP preference):** if any parent has subtasks already marked `[x]`, strongly prefer its remaining subtasks over subtasks of a parent with zero progress
+- Prefer ≤2 active parents per round, ≤4 subtasks dispatched per round — soft limits, not hard blocks
 - Sort by: P-level first (P1 > P2 > P3), then file order
 - Select top tasks for this round
 
@@ -196,7 +294,7 @@ Worktree 3 (feature/money-pool):
   - Bunq integration [execute]
 ```
 
-### 8.5. AUTO-TAG `[review]`
+### 8.5. AUTO-TAG `[review]` AND AUTO-INJECT `[reflect]`
 
 Before dispatching, check if each `[execute]` or `[test]` task should have `[review]` added. Add it
 automatically if the task meets **any** of these criteria (even if backlog author did not include it):
@@ -209,7 +307,26 @@ automatically if the task meets **any** of these criteria (even if backlog autho
 
 If a task already has `[review]`, keep it. Never remove `[review]` tags.
 
+**Auto-inject `[reflect]` subtask:**
+
+For any parent task being processed for the first time (no `[reflect]` subtask present at the end of its subtask list):
+
+1. Append `- [ ] \`[P2]\` \`[reflect]\` Verify result matches intent` as the last subtask under the parent
+2. Update `.orchestration/backlog.md` directly (whitelisted backlog write)
+3. The new `[reflect]` subtask will be picked up in a later round after other subtasks complete
+
 ### 9. DECOMPOSE IF NEEDED
+
+**Parent tasks without subtasks:**
+
+If a parent task has no subtasks yet, dispatch a single worker with `TASK_TYPE: [decompose-or-execute]`. The worker must:
+- Analyze the parent's Context and scope
+- Either propose subtasks (edit `.orchestration/backlog.md` to add them under the parent) and report `STATUS: done` with a note that subtasks were added, OR
+- Execute the task directly if it's small (≤3 files) and report `STATUS: done` normally
+
+If subtasks were added, the orchestrator picks them up in the next round (and auto-injects `[reflect]` via step 8.5).
+
+**Legacy flat-task decomposition (still applies to standalone tasks):**
 
 - If task is too large (>3 files, unclear scope):
     - Break into subtasks: `[research]` → `[plan]` → `[execute]` → `[test]`
@@ -265,6 +382,16 @@ Active Worktrees:
 
 **Worker Invocation:**
 
+**Before dispatching a subtask of a parent task:**
+
+If the parent task has no task file yet at `.orchestration/tasks/<slug>.md`:
+1. Compute the slug from the parent task name (kebab-case)
+2. Create `.orchestration/tasks/<slug>.md` with the schema shown in the "Task Context Files" section — copy Intent from the parent Context field
+3. Add `- Task file: .orchestration/tasks/<slug>.md` as a metadata bullet under the parent in `backlog.md`
+4. Then dispatch workers with `PARENT_TASK_FILE` set to that path
+
+Creating and updating task files is a whitelisted orchestrator operation.
+
 ```markdown
 Use Task tool with subagent_type="general-purpose", model="haiku"
 
@@ -272,12 +399,13 @@ Prompt template:
 Load the orchestrate-worker skill with these parameters:
 
 TASK_NAME: <task name>
-TASK_TYPE: <[research] | [plan] | [execute] | [test] | [ci]>
+TASK_TYPE: <[research] | [plan] | [execute] | [test] | [ci] | [reflect] | [decompose-or-execute]>
 PRIORITY: <P1 | P2 | P3>
 DEPENDENCIES: <comma-separated list or "none">
 CONTEXT: <from backlog>
 FILE_BOUNDARIES: <assigned file paths/patterns>
 WORKTREE_PATH: <path to worktree, e.g., .worktrees/events-page> (only for execute/test tasks)
+PARENT_TASK_FILE: <path to .orchestration/tasks/<slug>.md> (only for subtasks of a parent task, omit for standalone tasks)
 
 The worker will return a structured report.
 ```
@@ -416,6 +544,13 @@ For each completed task:
 - Keep dependency info for reference
 - Derive follow-up tasks, and update tasks in backlog
 - Derive user questions (if any)
+
+**Parent task completion:**
+
+After a subtask is marked done, check if all subtasks of its parent are Done:
+- If yes: move the parent to the Done section (preserve nesting), mark the parent `[x]`, add completion date
+- Archive the task file: move `.orchestration/tasks/<slug>.md` to `.orchestration/tasks/archive/<slug>.md` (whitelisted file operation)
+- If no: leave the parent in Active, continue
 
 Example:
 
@@ -712,13 +847,15 @@ As orchestration rounds accumulate, the orchestrator's context window grows. To 
 
 Even tasks that feel "internal" — like applying an improvement plan to `orchestrate.md` — must be dispatched to a worker.
 
-**Backlog state:**
+**Backlog state (hierarchical format):**
 ```markdown
 ## Active
 
-- [ ] `[P1]` `[execute]` Implement orchestrate command improvements
-    - Depends: Plan orchestrate command improvements
-    - Context: Apply 6 changes from `.orchestration/plans/YYYY-MM-DD-orchestrate-improvements-plan.md` to `.claude/commands/orchestrate.md`.
+- [ ] `[P1]` Implement orchestrate command improvements
+    - Context: Apply changes from `.orchestration/plans/YYYY-MM-DD-orchestrate-improvements-plan.md` to `.claude/commands/orchestrate.md`.
+    - Task file: .orchestration/tasks/implement-orchestrate-improvements.md
+    - [ ] `[P1]` `[execute]` Apply plan to orchestrate.md
+    - [ ] `[P2]` `[reflect]` Verify result matches intent
 ```
 
 **Round Actions:**

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -322,7 +322,14 @@ For any parent task being processed for the first time (no `[reflect]` subtask p
 If a parent task has no subtasks yet, dispatch a single worker with `TASK_TYPE: [decompose-or-execute]`. The worker must:
 - Analyze the parent's Context and scope
 - Either propose subtasks (edit `.orchestration/backlog.md` to add them under the parent) and report `STATUS: done` with a note that subtasks were added, OR
-- Execute the task directly if it's small (≤3 files) and report `STATUS: done` normally
+- Execute the task directly if it's small (≤3 files) using the same worktree/branch isolation as `[execute]` tasks:
+  1. Orchestrator creates a worktree: `git worktree add .worktrees/<feature-name> -b feature/<feature-name>`
+  2. Worker gets `WORKTREE_PATH` parameter and executes inside it (same as `[execute]` path)
+  3. Worker commits changes and runs `build`
+  4. Worker reports `STATUS: done` normally
+  5. Orchestrator proceeds with worktree PR creation (normal flow)
+
+This ensures Mode B (direct execution) receives identical isolation behavior to Mode A (subtask dispatch).
 
 If subtasks were added, the orchestrator picks them up in the next round (and auto-injects `[reflect]` via step 8.5).
 


### PR DESCRIPTION
## Summary

- Adds parent/child task structure to `backlog.md` — subtasks nested 4 spaces under parent
- Per-parent context file at `.orchestration/tasks/<slug>.md` (Intent, Decisions Log, Current State, Reflection)
- Auto-injects `[reflect]` subtask when orchestrator first processes a parent
- WIP preference: ≤2 active parents, ≤4 subtasks per round, finish-first bias
- New `[decompose-or-execute]` task type for parents with no subtasks yet
- `PARENT_TASK_FILE` parameter added to worker invocation for subtask context sharing

## Tasks Completed
- Added Hierarchical Tasks, Task Context Files, WIP Preference, Auto-Inject Reflect, Decomposition on Dispatch sections to `orchestrate.md`
- Updated Core Loop steps 5, 7, 8.5, 9, 10, 13
- Added `[reflect]` to Task Types table
- Updated `orchestrate-worker.md` with PARENT_TASK_FILE, Working with Parent Context, `[reflect]` and `[decompose-or-execute]` task types

## Testing
- Markdown-only changes — no build required

🤖 Generated by TeamBalance Orchestrate System

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced hierarchical task support enabling parent tasks with nested subtasks and independent dispatch
* Added `[reflect]` task type to validate task outcomes against stated intent
* Added `[decompose-or-execute]` task type for flexible task decomposition or direct execution
* Implemented persistent task context files for consistent state tracking throughout task lifecycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->