### PR TITLE
feat(orchestrate): extend task-file model to all backlog entries

### DIFF
--- a/.claude/commands/orchestrate-worker.md
+++ b/.claude/commands/orchestrate-worker.md
@@ -10,28 +10,24 @@ You are a focused worker agent in the TeamBalance orchestrate system. Your job i
 **Task Name:** {{TASK_NAME}}
 **Task Type:** {{TASK_TYPE}}
 **Priority:** {{PRIORITY}}
-**Dependencies:** {{DEPENDENCIES}}
-**Context:** {{CONTEXT}}
+**Task File:** {{TASK_FILE}} _(path to `.orchestration/tasks/<slug>.md` — read this first)_
 **File Boundaries:** {{FILE_BOUNDARIES}}
 **Worktree Path:** {{WORKTREE_PATH}} _(only for execute/test tasks)_
-**Parent Task File:** {{PARENT_TASK_FILE}} _(path to `.orchestration/tasks/<slug>.md` if subtask of a parent; empty for standalone tasks)_
 
-# Working with Parent Context
+# Working with Your Task File
 
-If `PARENT_TASK_FILE` is provided, you are a subtask of a larger parent task:
-
-**At start of work:**
-1. Read the file at `{{PARENT_TASK_FILE}}`
-2. Absorb the Intent, Subtasks progress, Decisions Log, and Current State
+**FIRST ACTION — before any other work:**
+1. Read the file at `{{TASK_FILE}}`
+2. Absorb the **Intent**, **Subtasks** progress (if hierarchical), **Decisions Log**, and **Current State**
 3. Let the Intent guide your implementation — don't drift from it
 
-**At end of work (before returning report):**
+**LAST ACTION — before returning your report:**
 1. Append to Decisions Log: `- YYYY-MM-DD (<task-type> worker): <key decision or outcome>`
-2. Overwrite Current State with a 1–3 sentence summary of where the work stands
-3. Mark your subtask line as `[x]` in the Subtasks section
+2. Overwrite Current State with a 1–3 sentence summary of where the work stands now
+3. If you are a subtask (Subtasks section is populated): mark your subtask line as `[x]`
 4. Save the file
 
-If `PARENT_TASK_FILE` is empty, you are a standalone task — behave as before.
+**File not found?** If `{{TASK_FILE}}` doesn't exist (unmigrated task), derive intent from `TASK_NAME` and proceed without a file — but note this in NOTES.
 
 # Task Type Instructions
 
@@ -43,8 +39,9 @@ If `PARENT_TASK_FILE` is empty, you are a standalone task — behave as before.
 - **After completion:**
   1. Add a follow-up `[plan]` task to `.orchestration/backlog.md` in the Active section
   2. The plan task should depend on user answering the questions
-  3. Format: `- [ ] \`[P1]\` \`[plan]\` <task name based on research>`
-- **Report:** List the research document created
+  3. Format: `- [ ] \`[P1]\` \`[plan]\` <task name>\n    - Depends: user answering questions in <research doc>\n    - Task file: .orchestration/tasks/<slug>.md`
+  4. **Create the follow-up task file** at `.orchestration/tasks/<slug>.md` in the same operation — populate Intent from your research findings summary
+- **Report:** List the research document and task file created
 
 **Research Document Template:**
 ```markdown
@@ -79,9 +76,10 @@ If `PARENT_TASK_FILE` is empty, you are a standalone task — behave as before.
 - **After completion:**
   1. Add a follow-up `[execute]` task to `.orchestration/backlog.md` in the Active section
   2. The execute task should depend on user approving the plan
-  3. Format: `- [ ] \`[P1]\` \`[execute]\` <task name> \`[review]\``
+  3. Format: `- [ ] \`[P1]\` \`[execute]\` <task name> \`[review]\`\n    - Depends: user approving plan\n    - Task file: .orchestration/tasks/<slug>.md`
   4. Tag with `[review]` if code changes are significant
-- **Report:** List the plan document created
+  5. **Create the follow-up task file** at `.orchestration/tasks/<slug>.md` in the same operation — populate Intent with a link to the plan doc and key decisions
+- **Report:** List the plan document and task file created
 
 **Plan Document Template:**
 ```markdown
@@ -157,9 +155,9 @@ If `PARENT_TASK_FILE` is empty, you are a standalone task — behave as before.
 
 ## [reflect]
 - **Goal:** Validate that the parent task's actual outcome matches its original intent
-- **Requires:** `PARENT_TASK_FILE` must be provided
+- **Requires:** `TASK_FILE` must be provided (points to the parent's task file)
 - **Actions:**
-  1. Read the full parent task file at `{{PARENT_TASK_FILE}}`
+  1. Read the full parent task file at `{{TASK_FILE}}`
   2. Compare the Intent section against the Decisions Log + Current State
   3. Decide: does the actual outcome match the original intent?
   4. Write a Reflection section into the task file:

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -167,9 +167,9 @@ Every parent task gets a persistent context file at `.orchestration/tasks/<slug>
 ```
 
 **Worker contract:**
-- Every subtask worker receives `PARENT_TASK_FILE: .orchestration/tasks/<slug>.md`
-- At start: read the file for context
-- At end: append a Decisions Log entry, overwrite Current State, mark its subtask line as `[x]`
+- Every worker (subtask or standalone) receives `TASK_FILE: .orchestration/tasks/<slug>.md`
+- At start: read the file for Intent, Decisions Log, and Current State
+- At end: append a Decisions Log entry, overwrite Current State, mark subtask line as `[x]` (subtasks only)
 
 # WIP Preference (Stop Starting, Start Finishing)
 
@@ -389,15 +389,18 @@ Active Worktrees:
 
 **Worker Invocation:**
 
-**Before dispatching a subtask of a parent task:**
+**Before dispatching any task (parent subtask OR standalone):**
 
-If the parent task has no task file yet at `.orchestration/tasks/<slug>.md`:
-1. Compute the slug from the parent task name (kebab-case)
-2. Create `.orchestration/tasks/<slug>.md` with the schema shown in the "Task Context Files" section — copy Intent from the parent Context field
-3. Add `- Task file: .orchestration/tasks/<slug>.md` as a metadata bullet under the parent in `backlog.md`
-4. Then dispatch workers with `PARENT_TASK_FILE` set to that path
+Ensure a task file exists at `.orchestration/tasks/<slug>.md`:
+1. Compute the slug from the task name (kebab-case, strip priority/type tags, max 60 chars)
+2. If file doesn't exist: create `.orchestration/tasks/<slug>.md` (copy Intent from inline `Context:` if present; otherwise write intent from task name)
+3. If backlog row has `Context:` but no `Task file:`: replace it with `- Task file: .orchestration/tasks/<slug>.md`
+4. Creating and updating task files is a **whitelisted orchestrator operation**
 
-Creating and updating task files is a whitelisted orchestrator operation.
+**Slug rules:**
+- Strip leading type/priority tags: `[P1] [execute] Fix foo → fix-foo`
+- Lowercase, kebab-case, ASCII only, max 60 chars
+- Suffix `-2`, `-3` on collision with existing files
 
 ```markdown
 Use Task tool with subagent_type="general-purpose", model="haiku"
@@ -408,14 +411,14 @@ Load the orchestrate-worker skill with these parameters:
 TASK_NAME: <task name>
 TASK_TYPE: <[research] | [plan] | [execute] | [test] | [ci] | [reflect] | [decompose-or-execute]>
 PRIORITY: <P1 | P2 | P3>
-DEPENDENCIES: <comma-separated list or "none">
-CONTEXT: <from backlog>
+TASK_FILE: <path to .orchestration/tasks/<slug>.md> (REQUIRED for all tasks)
 FILE_BOUNDARIES: <assigned file paths/patterns>
 WORKTREE_PATH: <path to worktree, e.g., .worktrees/events-page> (only for execute/test tasks)
-PARENT_TASK_FILE: <path to .orchestration/tasks/<slug>.md> (only for subtasks of a parent task, omit for standalone tasks)
 
 The worker will return a structured report.
 ```
+
+**Tolerance fallback:** If a row has no `Task file:` bullet and no `Context:` (unmigrated), materialize the task file lazily on first dispatch using the task name as intent — add the `Task file:` bullet to the backlog row in the same step.
 
 **File Boundary Assignment:**
 
@@ -529,7 +532,7 @@ Prompt template:
 Load the orchestrate-reviewer skill with these parameters:
 
 TASK_NAME: <task name>
-CONTEXT: <from backlog>
+TASK_FILE: <path to .orchestration/tasks/<slug>.md>
 FILES_CHANGED: <from worker report>
 COMMIT_SHA: <from worker report>
 


### PR DESCRIPTION
## Summary

- Replace `DEPENDENCIES`/`CONTEXT`/`PARENT_TASK_FILE` params with single `TASK_FILE` in worker invocation
- Workers read their task file first; fall back to deriving intent from `TASK_NAME` if file missing (unmigrated rows)
- `[research]` and `[plan]` workers now create follow-up task files alongside backlog rows
- `[reflect]` uses `TASK_FILE` instead of `PARENT_TASK_FILE`
- Added slug generation rules (lowercase kebab-case, max 60 chars, `-2`/`-3` suffix on collision)
- Reviewer template updated to pass `TASK_FILE` instead of `CONTEXT`
- Backlog format header updated: removed `Context:` row, task-file note now says "all tasks"

## Tasks Completed

- Implement dedicated task file per backlog entry (task #9)

## Testing

- Orchestrate system changes (markdown only — no compilation required)

🤖 Generated by TeamBalance Orchestrate System

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined task orchestration by consolidating task context into unified task file format for improved consistency.
  * Updated task workflow to ensure proper task file creation and initialization across all task types.
  * Enhanced task completion handling and context management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->