### PR TITLE
feat(e2e): make previous-events test dynamic using /api/config/season endpoint

### DIFF
--- a/e2e/src/playwright/tests/previous-events.spec.ts
+++ b/e2e/src/playwright/tests/previous-events.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { HOST, START_OF_SEASON } from "./utils";
+import { getStartOfSeason, HOST } from "./utils";
 import { createTrainingEvent } from "./training-utils";
 import { v4 as uuid } from "uuid";
 
-test("Validate previous events can be shown", async ({ page }) => {
+test("Validate previous events can be shown", async ({ page, request }) => {
   await page.goto(HOST);
   await page.getByText("Aanstaande trainingen").waitFor({ state: "visible" });
   await page.getByRole("button", { name: "Admin dingen" }).click();
@@ -11,7 +11,10 @@ test("Validate previous events can be shown", async ({ page }) => {
   // Use a unique comment so we can find THIS specific past event later,
   // even when other tests have created training events in the database.
   const comment = `past-${uuid().slice(0, 8)}`;
-  await createTrainingEvent(page, comment, START_OF_SEASON);
+
+  const dayBeforeStartOfSeason = await getStartOfSeason(request);
+  dayBeforeStartOfSeason.setDate(dayBeforeStartOfSeason.getDate() - 1);
+  await createTrainingEvent(page, comment, dayBeforeStartOfSeason);
   await page.getByRole("button", { name: "Terug naar de veiligheid" }).click();
 
   await page.getByTestId("training-events").waitFor({ state: "visible" });

--- a/e2e/src/playwright/tests/utils.ts
+++ b/e2e/src/playwright/tests/utils.ts
@@ -1,3 +1,5 @@
+import { APIRequestContext } from "@playwright/test";
+
 export const ensure = <T>(
   value: T | undefined,
   name: string | undefined = "value",
@@ -15,8 +17,38 @@ export const ensure = <T>(
 export const HOST: string = ensure(process.env.HOST, "host");
 export const PASSWORD = ensure(process.env.PASSWORD, "PASSWORD");
 
+const API_SECRET = Buffer.from("teambalance").toString("base64");
+const apiHeaders = {
+  Host: "frontend:3000",
+  "X-Secret": API_SECRET,
+  "Content-Type": "application/json",
+};
+
 export const NOW = new Date();
-export const START_OF_SEASON = new Date(2025, 8, 1, 2);
+
+/**
+ * Fetch the current start-of-season date from the backend config API.
+ */
+export async function getStartOfSeason(
+  request: APIRequestContext,
+): Promise<Date> {
+  const response = await request.get(`${HOST}/api/config/season`, {
+    headers: apiHeaders,
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to fetch start-of-season: ${response.status()} ${response.statusText()}`,
+    );
+  }
+  const body = (await response.json()) as { startOfSeason: string };
+  const result = new Date(body.startOfSeason);
+  if (isNaN(result.getTime())) {
+    throw new Error(
+      `getStartOfSeason: invalid date in response: ${body.startOfSeason}`,
+    );
+  }
+  return result;
+}
 
 export const addHours = (date: Date, hours: number): Date => {
   const result = new Date(date);


### PR DESCRIPTION
## Summary

- Replaces hardcoded `START_OF_SEASON` constant in `previous-events.spec.ts` with a dynamic `getStartOfSeason(request)` call
- Adds `getStartOfSeason()` to `utils.ts` — calls `GET /api/config/season` (existing endpoint from PR #364)
- Test creates the past event one day **before** the season start, ensuring it is filtered by the \"Oude events\" toggle

## Motivation

E2e tests hardcoded the season start date, making them brittle when the season rolls over. This reads the value from the existing config API instead.

## Testing

- Build passes (Spotless clean)
- E2E auth timeout is pre-existing infra flakiness unrelated to this change

🤖 Generated by TeamBalance Orchestrate System