### PR TITLE
fix(e2e): serve frontend via vite preview to eliminate Vite v8 cold-start flakiness

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -25,11 +25,10 @@ services:
 
 
   frontend:
-    image: teambalance/frontend
+    image: teambalance/frontend-e2e
     build:
       context: ./frontend
-      dockerfile: Dockerfile
-    command: npm start
+      dockerfile: Dockerfile.e2e
     depends_on:
       backend:
         condition: service_healthy
@@ -37,19 +36,15 @@ services:
       - "3000:3000"
     environment:
       VITE_SERVER_BACKEND: backend
-    volumes:
-      - ./frontend:/usr/src/app
-      - /usr/src/app/node_modules
     healthcheck:
-      # Use a real GET (not --spider/HEAD) so Vite actually compiles the JS entry
-      # point during the healthcheck. Without this, the first browser request from
-      # the e2e container triggers a cold Vite compilation that takes >60 s.
-      test: ["CMD", "sh", "-c", "wget -qO- http://127.0.0.1:3000/ > /dev/null && wget -qO- http://127.0.0.1:3000/index.tsx > /dev/null"]
-      interval: 30s
-      timeout: 90s
-      start_period: 30s
-      start_interval: 5s
-      retries: 5
+      # vite preview serves pre-built static assets — no compilation on first request,
+      # so a fast HEAD check is sufficient.
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/"]
+      interval: 5s
+      timeout: 5s
+      start_period: 10s
+      start_interval: 2s
+      retries: 10
 
   postgresql:
     image: postgres:16.13-alpine

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -22,11 +22,7 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Auth restoration via localStorage involves recursive API retries (up to
-     10x, ~5 s each). On CI with a slow backend + Vite v8 startup this can
-     take 30-60 s before the app renders authenticated content. Both timeouts
-     are raised so tests don't race against the startup auth flow. */
-  timeout: 90000,
+  timeout: 30000,
   expect: { timeout: 10000 },
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
@@ -78,7 +74,6 @@ export default defineConfig({
           ...devices["Desktop Safari"],
           storageState: ".auth/user.json",
         },
-        timeout: 90000,
         dependencies: ["setup"],
       },
     ] : []),

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,0 +1,35 @@
+# E2E Dockerfile: builds the frontend bundle and serves it with vite preview.
+# This eliminates Vite v8/Rolldown cold dep-bundling on first request,
+# which caused startup race conditions in CI e2e runs.
+
+FROM node:22-alpine AS build
+
+WORKDIR /usr/src/app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+  npm set cache /root/.npm && \
+  npm ci
+
+# Copy source and build for the e2e team (tovoheren4).
+# The vite root is src/main/react; --outDir dist puts output at src/main/react/dist.
+COPY . .
+RUN npx vite build --mode tovoheren4 --outDir dist --emptyOutDir
+
+# ---
+
+FROM node:22-alpine AS preview
+
+WORKDIR /usr/src/app
+
+# Copy node_modules (for the vite binary), config, and built assets.
+# The built assets land in src/main/react/dist (relative to vite root).
+COPY --from=build /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/package.json ./package.json
+COPY --from=build /usr/src/app/vite.config.js ./vite.config.js
+COPY --from=build /usr/src/app/src/main/react ./src/main/react
+
+# Serve with vite preview. --outDir matches the build step above.
+# --host exposes the server on all interfaces so Docker port mapping works.
+CMD ["node_modules/.bin/vite", "preview", "--outDir", "dist", "--host", "0.0.0.0"]

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -70,6 +70,9 @@ export default defineConfig(({ mode }) => {
     preview: {
       host: "0.0.0.0",
       port: 3000,
+      proxy: {
+        "/api": `http://${env.VITE_SERVER_BACKEND || "localhost"}:8080`,
+      },
     },
   };
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -60,9 +60,16 @@ export default defineConfig(({ mode }) => {
       proxy: {
         "/api": `http://${env.VITE_SERVER_BACKEND || "localhost"}:8080`,
       },
+      warmup: {
+        clientFiles: [
+          `./${root}/index.tsx`,
+          `./${root}/src/App.tsx`,
+        ],
+      },
     },
     preview: {
-      port: 3001,
+      host: "0.0.0.0",
+      port: 3000,
     },
   };
 });


### PR DESCRIPTION
## Summary
Permanently fixes the Vite v8 Docker e2e startup flakiness that fails the first CI run on most PRs (seen on #403, #395). Root cause: Rolldown cold dependency-bundling on the first request to the dev server + no warmup, so Playwright's wait would time out before the server was ready.

## Changes
- **`frontend/Dockerfile.e2e`** (new): multi-stage `vite build` → `vite preview` image (serves a production build, no cold-bundling race).
- **`compose.yml`**: e2e frontend now uses `Dockerfile.e2e`; healthcheck simplified to a fast HEAD probe (5s interval / 10s start) instead of the 90s GET band-aid.
- **`e2e/playwright.config.ts`**: startup timeout reverted 90s → 30s; removed webkit override.
- **`frontend/vite.config.js`**: `preview.host=0.0.0.0`, `preview.port=3000`; added `server.warmup` (index.tsx, src/App.tsx) for faster local dev.

## Testing
- `vite build` green (418ms); `docker compose config` validates.
- Real validation is this PR's own E2E run.

## Context
Research: `.orchestration/research/2026-06-01-vite-v8-docker-e2e-startup-latency.md`. User approved recommended defaults (Dockerfile.e2e + preview.port 3000).

🤖 Generated by TeamBalance Orchestrate System

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend service configuration to use pre-built static assets for E2E testing environments.
  * Optimized dev server startup with file preloading.
  * Adjusted preview server to port 3000.

* **Tests**
  * Reduced test timeout to 30 seconds for faster feedback cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->