### PR TITLE
fix(e2e): gate tests on backend health to eliminate backend-unreachable race

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,12 +15,15 @@ services:
       postgresql:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "-u", "admin:admin", "http://backend:8080/internal/actuator/health" ]
-      interval: 30s
-      timeout: 10s
-      start_period: 60s
+      # Healthchecks run inside the container — use localhost, not the service name.
+      # /internal/actuator/health requires auth (Spring Security requires fullyAuthenticated).
+      # Generous retries + short interval to handle Spring Boot cold-start on CI runners.
+      test: [ "CMD", "curl", "-f", "-u", "admin:admin", "http://localhost:8080/internal/actuator/health" ]
+      interval: 5s
+      timeout: 3s
+      start_period: 30s
       start_interval: 5s
-      retries: 5
+      retries: 20
 
 
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -13,6 +13,7 @@ dotenv.config({ quiet: true, path: path.resolve(__dirname, ".env") });
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  globalSetup: "./src/playwright/global-setup",
   testDir: "./src/playwright/tests",
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -38,8 +39,8 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "retain-on-failure",
     screenshot: {
-      mode: "only-on-failure"
-    }
+      mode: "only-on-failure",
+    },
   },
 
   /* Configure projects for major browsers.
@@ -58,25 +59,27 @@ export default defineConfig({
       dependencies: ["setup"],
     },
 
-    ...(!process.env.CI ? [
-      {
-        name: "firefox",
-        use: {
-          ...devices["Desktop Firefox"],
-          storageState: ".auth/user.json",
-        },
-        dependencies: ["setup"],
-      },
+    ...(!process.env.CI
+      ? [
+          {
+            name: "firefox",
+            use: {
+              ...devices["Desktop Firefox"],
+              storageState: ".auth/user.json",
+            },
+            dependencies: ["setup"],
+          },
 
-      {
-        name: "webkit",
-        use: {
-          ...devices["Desktop Safari"],
-          storageState: ".auth/user.json",
-        },
-        dependencies: ["setup"],
-      },
-    ] : []),
+          {
+            name: "webkit",
+            use: {
+              ...devices["Desktop Safari"],
+              storageState: ".auth/user.json",
+            },
+            dependencies: ["setup"],
+          },
+        ]
+      : []),
 
     /* Test against mobile viewports. */
     // {

--- a/e2e/src/playwright/global-setup.ts
+++ b/e2e/src/playwright/global-setup.ts
@@ -1,0 +1,49 @@
+/**
+ * Global setup: wait for the backend health endpoint before any tests run.
+ *
+ * Defense-in-depth on top of the Docker healthcheck — ensures the backend
+ * is actually serving before Playwright dispatches the first test, even if
+ * the container scheduler starts the e2e container slightly early.
+ *
+ * The backend actuator path is /internal/actuator/health (auth required).
+ * In the Docker Compose network the backend is reachable as http://backend:8080.
+ */
+
+const BACKEND_HEALTH_URL = `http://${process.env.VITE_SERVER_BACKEND ?? "backend"}:8080/internal/actuator/health`;
+const TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 2_000;
+
+async function waitForBackend(): Promise<void> {
+  const deadline = Date.now() + TIMEOUT_MS;
+  const credentials = Buffer.from("admin:admin").toString("base64");
+
+  console.log(`[global-setup] Waiting for backend at ${BACKEND_HEALTH_URL} …`);
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BACKEND_HEALTH_URL, {
+        headers: { Authorization: `Basic ${credentials}` },
+        signal: AbortSignal.timeout(3_000),
+      });
+      if (res.ok) {
+        console.log(`[global-setup] Backend is healthy (HTTP ${res.status})`);
+        return;
+      }
+      console.log(
+        `[global-setup] Backend returned HTTP ${res.status}, retrying…`,
+      );
+    } catch (err) {
+      // connection refused / timeout — backend not up yet
+      console.log(
+        `[global-setup] Backend not reachable yet (${(err as Error).message}), retrying…`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  throw new Error(
+    `[global-setup] Backend did not become healthy within ${TIMEOUT_MS / 1000}s`,
+  );
+}
+
+export default waitForBackend;


### PR DESCRIPTION
## Summary
Fixes the intermittent backend-unreachable race in e2e that has repeatedly failed first CI runs (and blocked #395): Playwright started before the backend was serving → all `/api/*` calls connection-refused → homepage never rendered → every test timed out in `beforeEach`. Same flake also hit master.

## Changes
- **`compose.yml`**: backend healthcheck fixed to `localhost:8080/internal/actuator/health` (was using the `backend:8080` service name, which is unreliable from inside the container; actuator base-path is `/internal/actuator` per application.yml, Basic auth admin:admin). Timing tightened to interval 5s / 20 retries / start_period 30s. The e2e runner now `depends_on` backend with `condition: service_healthy`.
- **`e2e/playwright.config.ts` + `e2e/src/playwright/global-setup.ts`**: defense-in-depth — globalSetup polls the backend health endpoint until 200 before any test runs.

## Testing
- `docker compose config` validates; prettier clean.
- Real validation is this PR's own e2e run.

## Complements
PR #404 (frontend readiness via vite preview). Together they gate e2e on both frontend AND backend readiness.

🤖 Generated by TeamBalance Orchestrate System

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test environment setup with improved backend service availability detection and better timeout handling during startup.

* **Chores**
  * Updated service health check configuration for more reliable startup detection and improved cold-start tolerance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->