### PR TITLE
fix(frontend): correct vite warmup clientFiles paths (drop double root prefix)

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -62,8 +62,8 @@ export default defineConfig(({ mode }) => {
       },
       warmup: {
         clientFiles: [
-          `./${root}/index.tsx`,
-          `./${root}/src/App.tsx`,
+          `./index.tsx`,
+          `./src/App.tsx`,
         ],
       },
     },


### PR DESCRIPTION
## Summary
Follow-up to CodeRabbit review on merged #404. `server.warmup.clientFiles` in `frontend/vite.config.js` was double-prefixed with `root` (`src/main/react`), resolving to nonexistent `src/main/react/src/main/react/index.tsx` → warmup silently no-op'd.

## Change
- `./${root}/index.tsx` → `./index.tsx`
- `./${root}/src/App.tsx` → `./src/App.tsx`

(Vite resolves warmup paths relative to `root`; both target files confirmed present.)

## Testing
- `npm run build` passes.
- Local-dev-only change (warmup is a dev-server nicety); no runtime/CI behavior impact.

🤖 Generated by TeamBalance Orchestrate System

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved development server startup behavior to warm essential client files earlier, reducing initial dev-server startup time and improving local reload responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->