### PR TITLE
fix(e2e): restore playwright timeout to 90s and capture backend logs on failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: E2E tests
-        run: make e2e  || (docker compose logs frontend && exit 1)
+        run: make e2e  || (docker compose logs frontend; docker compose logs backend; exit 1)
         env:
           CI: true
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -23,7 +23,10 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  timeout: 30000,
+  /* Auth restoration via localStorage involves recursive API retries (up to
+   * 10×, ~5 s each). On CI with a slow backend + Vite startup this can
+   * take 30–60 s before the app renders authenticated content. */
+  timeout: 90000,
   expect: { timeout: 10000 },
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [


### PR DESCRIPTION
## Summary
Fixes the e2e failures that have blocked PR #395. PR #404 inadvertently lowered the Playwright test timeout from 90000ms to 30000ms. But the app's startup auth check (`recursiveAuth`) can take up to ~50s (10 retries × 5s), so tests time out in `beforeEach` while the page is still showing "Wachtwoord controleren..." — every test fails at homepage render. This was initially misread as a mid-run backend crash; Playwright page snapshots proved it's the auth-check state, not a backend error.

## Changes
- **`e2e/playwright.config.ts`**: test `timeout` 30000 → 90000 (restores the pre-#404 value).
- **`.github/workflows/build.yml`**: also capture `docker compose logs backend` on e2e failure (previously only frontend logs were captured) — makes future mid-run issues debuggable.

## Testing
- playwright config verified (timeout: 90000); build.yml YAML valid.
- Real validation is this PR's own e2e run — expect a clean pass.

## Context
Root-cause research: `.orchestration/research/2026-06-01-mid-run-backend-unreachable-race.md`. Unblocks PR #395 (MUI v6) after rebase.

🤖 Generated by TeamBalance Orchestrate System