### PR TITLE
docs(orchestrate): make the workflow diagnose-first + bounded CI checks + post-handover reflection

### DIFF
--- a/.claude/commands/orchestrate-worker.md
+++ b/.claude/commands/orchestrate-worker.md
@@ -185,22 +185,23 @@ You are a focused worker agent in the TeamBalance orchestrate system. Your job i
   2. Report as usual with commit SHA, tests, build status
 
 ## [ci]
-- **Goal:** Monitor PR CI status, validate review comments, rebase/merge when green
+- **Goal:** Take ONE bounded action on a PR's CI, then return. **Never sit and watch.**
 - **No code changes** (unless a trivial rebase conflict must be resolved)
-- **Actions — follow in order:**
-  1. Run `gh pr checks <number>` to see current status
-  2. Run `gh pr view <number> --comments` to check for unresolved review comments
-  3. If **unresolved review comments exist**: report `STATUS: blocked`, list comments in NOTES
-  4. If **all checks pending**: wait 2 minutes, re-check (up to 3 retries; still pending → `STATUS: blocked`)
-  5. If **checks failed**: check if failure matches a known blocker in task Context
-     - If yes → `STATUS: blocked` with blocker name
-     - If no → investigate; dispatch mental fix plan; report `STATUS: blocked` with details for orchestrator
-  6. If **all checks pass and no unresolved comments**: merge PR
+- **CRITICAL — do NOT long-poll.** A `[ci]` worker must finish in a single short check (target < 2 min, hard cap ~5 min). Do NOT use `gh ... --watch`, do NOT loop "wait N minutes and re-check". Long watches get killed by socket timeout and waste the worker. The **orchestrator** is responsible for waiting between rounds (via ScheduleWakeup) and only dispatches you once there is something to act on.
+- **Actions — follow in order, then return immediately:**
+  1. Run `gh pr checks <number>` ONCE to read current status.
+  2. Run `gh pr view <number> --comments` to check for unresolved review comments.
+  3. If **unresolved review comments exist**: report `STATUS: blocked`, list comments in NOTES.
+  4. If **checks still PENDING/QUEUED/IN_PROGRESS**: do a single short bounded wait at most (≤90s) and re-read ONCE. If still not terminal → report `STATUS: blocked` with `NOTES: "CI still pending on run <id>; orchestrator should re-check next round"`. Do NOT keep looping.
+  5. If **checks FAILED**: check if it matches a known blocker in task Context.
+     - If yes → `STATUS: blocked` with the blocker name.
+     - If no → pull the failing log ONCE (`gh run view <id> --log-failed`), summarize the real cause, and report `STATUS: blocked` with specifics for the orchestrator to dispatch a fix. Do NOT attempt the fix yourself.
+  6. If **all checks PASS and no unresolved comments**: merge PR
      ```bash
-     gh pr merge <number> --squash --auto
+     gh pr merge <number> --squash
      ```
-  7. Report merge confirmation in NOTES
-- **Report:** PR number, check status, merge outcome or blocker reason
+  7. Report merge confirmation (and merge SHA) in NOTES.
+- **Report:** PR number, terminal check status (or "still pending"), merge outcome or precise blocker reason.
 
 # File Boundaries
 

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -85,20 +85,24 @@ Never proceed with a broken build.
 
 **`[ci]` Worker Decision Tree:**
 
-When dispatching a `[ci]` task, instruct the worker to follow these steps in order:
+**Bounded-check rule (CRITICAL — avoids killed background workers):** A `[ci]` worker must take ONE short action and return (target < 2 min). It must NEVER sit and watch CI (`gh ... --watch`, or "wait N minutes × M retries"). Long watches get killed by socket timeout (~45 min) and burn the worker for nothing. **Waiting between checks is the ORCHESTRATOR's job, not the worker's:** when CI is still pending, the worker returns `STATUS: blocked (still pending)`, and the orchestrator schedules a re-check next round via `ScheduleWakeup` (~300–600s). Only dispatch a `[ci]` worker once there is something actionable to do.
 
-1. Run `gh pr checks <number>` to see current status
+When dispatching a `[ci]` task, instruct the worker to follow these steps in order, then return immediately:
+
+1. Run `gh pr checks <number>` ONCE to see current status
 2. Run `gh pr view <number> --comments` to check for review comments that need addressing
 3. If **review comments exist and are unresolved**: report `STATUS: blocked`, list the comments in NOTES
-4. If **all checks pending**: wait 2 minutes, re-check (up to 3 retries; if still pending after 3 retries → `STATUS: blocked`)
+4. If **checks still pending/in-progress**: at most ONE short bounded wait (≤90s) and re-read once; if still not terminal → report `STATUS: blocked` with `NOTES: "CI still pending on run <id>"`. Do NOT keep looping — the orchestrator re-checks next round.
 5. If **checks failed**: check if failure matches a *known blocker* listed in the task Context
    - If yes → report `STATUS: blocked` immediately with the known blocker name
-   - If no → investigate the new failure; dispatch a fix worker; re-run CI validation after fix
+   - If no → pull the failing log once (`gh run view <id> --log-failed`), summarize the real cause, report `STATUS: blocked` with specifics; the orchestrator dispatches a fix worker (the worker does not fix it itself)
 6. If **all checks pass and no unresolved comments**: merge PR
    ```bash
-   gh pr merge <number> --squash --auto
+   gh pr merge <number> --squash
    ```
 7. Add a note to the handover: "PR #<number> merged — <branch>"
+
+**Orchestrator polling pattern (replaces worker long-watches):** At the top of each round the orchestrator may directly run `gh pr checks <number>` (a single read) to see if an in-flight PR has reached a terminal state. If still pending → do other eligible work, then `ScheduleWakeup` (~300–600s) and re-check next round. If terminal (pass/fail) → dispatch a single bounded `[ci]` worker to merge or to diagnose+report. This keeps all waiting at the round boundary, where it is cheap and cannot kill a worker.
 
 **`[ci]` Escalation Rule (max retries):**
 
@@ -799,11 +803,14 @@ Active PRs:
 - Run `git worktree list`, `git worktree add`, `git worktree remove` — worktree lifecycle (step 9.5)
 - Run `gh pr create` — PR creation per completed worktree (MR Creation section)
 
+**Allowed at a round boundary (single read, not monitoring):**
+- Run `gh pr checks <number>` ONCE to decide whether to dispatch a `[ci]` worker (merge/diagnose) or `ScheduleWakeup` and re-check next round.
+
 **Do NOT directly:**
 - Read code files (`.kt`, `.tsx`, `.ts`, `.sql`, etc.) — delegate to workers
 - Analyze test output — workers return structured summaries
 - Run detailed git commands (diff, log, status on feature branches) — workers report commit SHAs
-- Run `gh pr checks`, `gh run view`, `gh run list`, `gh pr view --comments` — CI monitoring belongs inside `[ci]` workers, never run by the orchestrator directly
+- Run `gh run view --log`, `gh pr view --comments`, or any iterative CI watch/poll loop — deep log analysis and merging belong inside a bounded `[ci]` worker. Never sit in a watch loop (it gets killed by socket timeout). The single `gh pr checks` read above is the only direct CI touch allowed.
 
 # Context Window Hygiene
 


### PR DESCRIPTION
Process hardening for the orchestrate skill, distilled from the MUI-v6 session retrospective. **Docs/prompt only** (`.claude/commands/`) — no code or CI behavior changes.

## Why
Landing MUI v6 took far more rounds than it should have. Root causes, all process — not code:
- A self-introduced regression (#404 silently dropped the Playwright test timeout 90s→30s) went unreviewed and was misdiagnosed as "flaky E2E" / "backend race" for ~4–5 rounds.
- Blind retries: CI re-triggered on a "probably flaky" hunch; an e2e selector "fixed" by guessing twice before someone read the actual trace.
- `[ci]` workers told to "wait 2 min × 3 retries" became 45-min watches that got killed by socket timeout.
- Workers sometimes ended on "monitoring…" instead of a structured report, so work had to be re-verified by hand (a "fix" reported done was never pushed).

## Changes

### `[ci]` flow (orchestrate.md + orchestrate-worker.md)
- **Bounded checks** — workers take ONE short check (<2 min) and return; never `--watch`/retry-loop. Waiting moves to the round boundary via `ScheduleWakeup`; a single `gh pr checks` read is allowed to the orchestrator.
- **Diagnose-before-retry** — no blind re-runs. "Flaky" requires cited evidence (same signature on master + a known passing run); otherwise read `--log-failed` and classify first.
- **Escalation = HARD STOP** — 3 blocks on the *same* PR → escalate with the Failure Ledger, no 4th attempt.

### Reviewer (orchestrate-reviewer.md)
- **Behavioral-config regression guard** (checklist §7 + auto-fail #6): any changed timeout / healthcheck timing / retry / port / limit must be stated **old → new** with justification. Would have caught the 90s→30s drop.

### Worker (orchestrate-worker.md)
- **Strict final-message contract** — last message MUST be the verified structured report; a mid-stream "monitoring…" ending is not completion.
- **Evidence-first for selector/DOM fixes** — use the real trace/DOM, never guess; forbidden to re-guess after a ledger-recorded prior failure.

### Task/spec files (orchestrate.md schema)
- Added **Definition of Done** (concrete + the exact verify command) and an append-only **Failure Ledger** so diagnosis is cumulative across rounds instead of restarted.

### New step 15.5 — mandatory post-handover reflection
After ANY handover request, a self-reflection now runs automatically: 3 things that worked / 3 that didn't + improvement suggestions scoped to workflow / spec-files / CLAUDE.md, then ask which to action.

## Commits
- `93c9d2e` bound [ci] worker checks; orchestrator polls between rounds
- `cb4d0ab` diagnose-first, regression guard, failure ledger, mandatory post-handover reflection

🤖 Generated with [Claude Code](https://claude.com/claude-code)