### PR TITLE
docs(orchestrate): diagnose-first, regression guard, failure ledger, post-handover reflection

### DIFF
--- a/.claude/commands/orchestrate-reviewer.md
+++ b/.claude/commands/orchestrate-reviewer.md
@@ -48,6 +48,12 @@ You are a code reviewer in the TeamBalance orchestrate system. Your job is to re
 - [ ] No breaking changes to existing functionality
 - [ ] Fits within assigned file boundaries
 
+## 7. Behavioral-Config Regression Guard
+For ANY changed numeric / timing / threshold / CI / infra value — test or request timeouts, healthcheck interval/retries/start_period, retry counts, ports, memory limits, polling intervals, workflow/CI config — the diff MUST be examined and stated as **old → new**, with a one-line justification for the change.
+- [ ] Every such changed value is listed as `old → new` with a reason
+- [ ] No value was silently lowered/raised as an incidental side effect of an unrelated change
+- [ ] If a value was changed without justification → flag it (this is how a test timeout was once silently dropped 90s→30s and broke e2e for days)
+
 # Context-Mode Tools
 
 Use context-mode tools to review code efficiently:
@@ -63,6 +69,7 @@ These issues mean automatic `VERDICT: fail`:
 3. Security vulnerability introduced
 4. Code modified outside assigned file boundaries
 5. Obvious logic error that will cause runtime failure
+6. A behavioral-config value (timeout, healthcheck timing, retry count, port, limit) changed with NO stated old→new justification (see checklist §7)
 
 # Reporting Format
 

--- a/.claude/commands/orchestrate-worker.md
+++ b/.claude/commands/orchestrate-worker.md
@@ -18,14 +18,16 @@ You are a focused worker agent in the TeamBalance orchestrate system. Your job i
 
 **FIRST ACTION — before any other work:**
 1. Read the file at `{{TASK_FILE}}`
-2. Absorb the **Intent**, **Subtasks** progress (if hierarchical), **Decisions Log**, and **Current State**
-3. Let the Intent guide your implementation — don't drift from it
+2. Absorb the **Intent**, **Definition of Done**, **Subtasks** progress (if hierarchical), **Decisions Log**, **Failure Ledger**, and **Current State**
+3. Let the Intent + Definition of Done guide your work — don't drift from it
+4. **Check the Failure Ledger first:** if it records a failure signature or a ruled-out cause relevant to your task, do NOT repeat that approach — build on what's already known instead of re-diagnosing from scratch
 
 **LAST ACTION — before returning your report:**
 1. Append to Decisions Log: `- YYYY-MM-DD (<task-type> worker): <key decision or outcome>`
-2. Overwrite Current State with a 1–3 sentence summary of where the work stands now
-3. If you are a subtask (Subtasks section is populated): mark your subtask line as `[x]`
-4. Save the file
+2. If you hit a build/test/CI failure, append its signature + diagnosed (or ruled-out) cause to the **Failure Ledger** — even if you didn't fully fix it. This is what lets the next round avoid re-deriving it.
+3. Overwrite Current State with a 1–3 sentence summary of where the work stands now
+4. If you are a subtask (Subtasks section is populated): mark your subtask line as `[x]`
+5. Save the file
 
 **File not found?** If `{{TASK_FILE}}` doesn't exist (unmigrated task), derive intent from `TASK_NAME` and proceed without a file — but note this in NOTES.
 
@@ -133,6 +135,7 @@ You are a focused worker agent in the TeamBalance orchestrate system. Your job i
   7. Commit changes with descriptive message
   8. Run `build` to verify
 - **Commit message format:** `<type>: <description>` (e.g., `feat: add event list component`)
+- **Evidence-first for test/selector/DOM fixes (CRITICAL — no blind guessing):** When fixing a failing test that depends on a selector, DOM structure, or library API (e.g. an e2e locator, a component query), you MUST base the fix on the ACTUAL rendered output, not a guess. Pull the real evidence: the Playwright trace / DOM snapshot from the failed run (`gh run download <id>`), and/or the actual component source (the `label`, role, props it renders). If the task file's Failure Ledger shows a PRIOR attempt at this same fix already failed, you are FORBIDDEN from trying another guessed selector — gather the rendered-DOM evidence first and cite it in your report. (Two blind selector swaps cost extra CI rounds before the trace-based fix worked; do not repeat that.)
 - **After completion (if not already tagged [review]):**
   1. Consider if code review is needed (significant changes, new features, complex logic)
   2. If yes: task should have been tagged `[review]` in backlog
@@ -245,6 +248,8 @@ FOLLOW-UP: <comma-separated list of follow-up tasks>
 USER-QUESTIONS: <comma-separated list of user questions>
 NOTES: <one line, only if something unexpected happened>
 ```
+
+**Final-message contract (CRITICAL):** Your LAST message MUST be this structured report. An intermediate message like "the monitor is running, I'll wait…" or "CI has started, waiting…" is NOT a valid completion — if you end on one, the orchestrator cannot tell what you actually did and must redo your work by hand (this has happened: a "fix" was reported as done but never pushed). Before you finish: re-verify the claim you're about to report (push actually landed → `git log origin/<branch> -1`; merge actually happened → `gh pr view <n> --json state`; build passed → you saw it pass). Report only verified outcomes. If you ran out of steps without a terminal result, report `STATUS: blocked` with exactly where you stopped — never imply success you didn't confirm.
 
 **Do not include:**
 - Code snippets

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -102,15 +102,21 @@ When dispatching a `[ci]` task, instruct the worker to follow these steps in ord
    ```
 7. Add a note to the handover: "PR #<number> merged — <branch>"
 
+**Diagnose-before-retry (CRITICAL — no blind re-runs):** NEVER re-trigger / re-run CI on a "probably flaky" hunch. A "flaky" classification is only valid with **evidence**: the SAME failure signature observed on `master` (or another known-good ref) AND a prior passing run of the same suite — cite both. Absent that evidence, you MUST `gh run view <id> --log-failed` and classify the real cause before any re-run. A re-run without a cited flaky-justification is a process violation. Record the failure signature in the task file's Failure Ledger (see Task Context Files) so the next round does not re-diagnose from scratch.
+
 **Orchestrator polling pattern (replaces worker long-watches):** At the top of each round the orchestrator may directly run `gh pr checks <number>` (a single read) to see if an in-flight PR has reached a terminal state. If still pending → do other eligible work, then `ScheduleWakeup` (~300–600s) and re-check next round. If terminal (pass/fail) → dispatch a single bounded `[ci]` worker to merge or to diagnose+report. This keeps all waiting at the round boundary, where it is cheap and cannot kill a worker.
 
-**`[ci]` Escalation Rule (max retries):**
+**`[ci]` Escalation Rule (HARD STOP — max retries):**
 
-If a `[ci]` task has returned `STATUS: blocked` 3 or more times across rounds (check handover history),
-the orchestrator must escalate to the user rather than re-dispatching. Present:
+If the **same PR** has reached `STATUS: blocked` on CI **3 times across rounds** (count from the task file's Failure Ledger / handover history), the orchestrator MUST stop and escalate to the user — it may NOT dispatch a 4th fix/retry attempt on that PR. This is a hard stop, not a preference. After 2 blocks on one PR, treat the 3rd as the final attempt and prepare to escalate.
+
+Escalate by presenting:
 - PR number and URL
-- All known blockers from previous rounds
-- Ask user what action to take (close PR, fix blocker, override)
+- The **Failure Ledger**: each distinct failure signature seen, the cause ruled in/out, and what was tried
+- A recommendation (fix-the-cause / admin-merge / pause / close) with tradeoffs
+- Ask the user what action to take
+
+Rationale: blind repetition past 3 attempts is how a single PR consumed many rounds of CI time. The ledger makes the escalation concrete instead of "it keeps failing."
 
 # Hierarchical Tasks
 
@@ -155,6 +161,9 @@ Every parent task gets a persistent context file at `.orchestration/tasks/<slug>
 ## Intent
 <parent Context field, verbatim>
 
+## Definition of Done
+<concrete, verifiable success criteria + the EXACT command(s) that prove it, e.g. "PR #NNN merged to master" / "`make build` green" / "e2e suite passes in CI run". Avoid vague "make it work".>
+
 ## Subtasks
 - [ ] <subtask 1 name>
 - [ ] <subtask 2 name>
@@ -162,6 +171,9 @@ Every parent task gets a persistent context file at `.orchestration/tasks/<slug>
 
 ## Decisions Log
 (Appended by each worker)
+
+## Failure Ledger
+(Append-only. Each distinct failure signature seen, its diagnosed/ruled-out cause, and what was tried. Prevents re-diagnosing the same failure from scratch each round. Format: `- <date>: <signature> → <cause / ruled-out> → <action taken>`)
 
 ## Current State
 (Overwritten by each worker)
@@ -656,6 +668,22 @@ Create `.orchestration/handover/YYYY-MM-DD-HH-MM-round-N.md`:
 - {{if plan was approved: Ready to execute [taskname]}}
 - {{if worktree ready: Create MR for [worktree-name]}}
 ```
+
+### 15.5. SELF-REFLECTION (MANDATORY after any handover request)
+
+**Trigger:** Whenever the user requests a handover (e.g. "prepare for handover"), or a final/end-of-session handover is written, the orchestrator MUST immediately follow the handover with a self-reflection. This is not optional and is not skippable — writing the handover is no longer the last step; the reflection is.
+
+Produce, in the response (not a file unless asked):
+
+1. **3 things that worked well** this session — concrete, with the specific evidence/example.
+2. **3 things that did NOT work well** — concrete, naming the actual failure (wasted rounds, misdiagnosis, blind retries, killed workers, etc.). Be candid, not performative.
+3. **Improvement suggestions**, each explicitly scoped to WHERE the change lands:
+   - the **orchestrate workflow** (`.claude/commands/orchestrate*.md`),
+   - the way **task/spec files** are created, or
+   - **CLAUDE.md / standing instructions** at your disposal.
+4. End by asking the user which suggestions to action (do not self-apply config/instruction changes without consent).
+
+Keep it tight and honest — the goal is cumulative process improvement, not a status recap (the handover already covered status).
 
 ### 16. INCREMENT ROUND
 


### PR DESCRIPTION
Follow-up to #408. The squash-merge of #408 captured only its **first** commit (bounded `[ci]` checks). This PR adds the **second** commit's content, which never reached master.

**Docs/prompt only** (`.claude/commands/`) — no code or CI behavior changes.

## Changes
- **`[ci]` diagnose-before-retry** (`orchestrate.md`): no blind re-runs; "flaky" requires cited evidence (same failure signature on master + a known passing run), otherwise read `--log-failed` and classify first.
- **Escalation = HARD STOP** (`orchestrate.md`): 3 blocks on the *same* PR → escalate with the Failure Ledger, no 4th attempt.
- **Behavioral-config regression guard** (`orchestrate-reviewer.md`, §7 + auto-fail #6): any changed timeout / healthcheck timing / retry / port / limit must be stated **old → new** with justification. (Would have caught the silent 90s→30s test-timeout regression that broke e2e for days.)
- **Strict final-message contract** (`orchestrate-worker.md`): a worker's last message MUST be the verified structured report — a mid-stream "monitoring…" ending is not completion.
- **Evidence-first for selector/DOM fixes** (`orchestrate-worker.md`): use the real trace/DOM, never guess; forbidden to re-guess after a ledger-recorded prior failure.
- **Task files** (`orchestrate.md` schema): add **Definition of Done** (with the exact verify command) and an append-only **Failure Ledger** so diagnosis is cumulative across rounds.
- **New step 15.5** (`orchestrate.md`): after ANY handover request, a self-reflection is mandatory (3 worked / 3 didn't + improvement suggestions scoped to workflow / spec-files / CLAUDE.md, then ask which to action).

## Provenance
Cherry-pick of `cb4d0ab` (originally on the #408 branch, dropped by the squash) onto current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)