### PR TITLE
fix(e2e): eliminate flaky pipeline (backend logs + API readiness probe + one-time page check)

### DIFF
--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -108,7 +108,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: E2E tests
-        run: make e2e  || (docker compose logs frontend && exit 1)
+        run: make e2e  || (docker compose logs frontend; docker compose logs backend; exit 1)
         env:
           CI: true
 

--- a/e2e/src/playwright/global-setup.ts
+++ b/e2e/src/playwright/global-setup.ts
@@ -1,48 +1,79 @@
 /**
- * Global setup: wait for the backend health endpoint before any tests run.
+ * Global setup: wait for the backend to be fully ready before any tests run.
  *
  * Defense-in-depth on top of the Docker healthcheck — ensures the backend
- * is actually serving before Playwright dispatches the first test, even if
- * the container scheduler starts the e2e container slightly early.
+ * is actually serving authenticated API routes before Playwright dispatches
+ * the first test, even if the container scheduler starts the e2e container
+ * slightly early.
  *
- * The backend actuator path is /internal/actuator/health (auth required).
+ * Two-stage readiness check:
+ *   1. Actuator health: /internal/actuator/health (Spring Boot readiness)
+ *   2. API probe: /api/users (authenticated application route) — closes the
+ *      gap where actuator reports healthy but the Spring Security filter chain
+ *      and schema initialization are still completing.
+ *
  * In the Docker Compose network the backend is reachable as http://backend:8080.
  */
 
-const BACKEND_HEALTH_URL = `http://${process.env.VITE_SERVER_BACKEND ?? "backend"}:8080/internal/actuator/health`;
+const BACKEND_HOST = `http://${process.env.VITE_SERVER_BACKEND ?? "backend"}:8080`;
+const BACKEND_HEALTH_URL = `${BACKEND_HOST}/internal/actuator/health`;
+const BACKEND_API_URL = `${BACKEND_HOST}/api/users`;
 const TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 2_000;
 
-async function waitForBackend(): Promise<void> {
-  const deadline = Date.now() + TIMEOUT_MS;
-  const credentials = Buffer.from("admin:admin").toString("base64");
-
-  console.log(`[global-setup] Waiting for backend at ${BACKEND_HEALTH_URL} …`);
+async function pollUntilOk(
+  url: string,
+  credentials: string,
+  deadline: number,
+  label: string,
+): Promise<void> {
+  console.log(`[global-setup] Waiting for ${label} at ${url} …`);
 
   while (Date.now() < deadline) {
     try {
-      const res = await fetch(BACKEND_HEALTH_URL, {
+      const res = await fetch(url, {
         headers: { Authorization: `Basic ${credentials}` },
         signal: AbortSignal.timeout(3_000),
       });
       if (res.ok) {
-        console.log(`[global-setup] Backend is healthy (HTTP ${res.status})`);
+        console.log(`[global-setup] ${label} ready (HTTP ${res.status})`);
         return;
       }
       console.log(
-        `[global-setup] Backend returned HTTP ${res.status}, retrying…`,
+        `[global-setup] ${label} returned HTTP ${res.status}, retrying…`,
       );
     } catch (err) {
-      // connection refused / timeout — backend not up yet
       console.log(
-        `[global-setup] Backend not reachable yet (${(err as Error).message}), retrying…`,
+        `[global-setup] ${label} not reachable yet (${(err as Error).message}), retrying…`,
       );
     }
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
   }
 
   throw new Error(
-    `[global-setup] Backend did not become healthy within ${TIMEOUT_MS / 1000}s`,
+    `[global-setup] ${label} did not become ready within ${TIMEOUT_MS / 1000}s`,
+  );
+}
+
+async function waitForBackend(): Promise<void> {
+  const deadline = Date.now() + TIMEOUT_MS;
+  const credentials = Buffer.from("admin:admin").toString("base64");
+
+  // Stage 1: actuator health (fast Spring Boot readiness indicator)
+  await pollUntilOk(
+    BACKEND_HEALTH_URL,
+    credentials,
+    deadline,
+    "backend actuator",
+  );
+
+  // Stage 2: authenticated API route — confirms the Spring Security filter
+  // chain and tenant schema are fully initialised and serving API responses.
+  await pollUntilOk(
+    BACKEND_API_URL,
+    credentials,
+    deadline,
+    "backend API (/api/users)",
   );
 }
 

--- a/e2e/src/playwright/global-setup.ts
+++ b/e2e/src/playwright/global-setup.ts
@@ -13,6 +13,8 @@
  *      and schema initialization are still completing.
  *
  * In the Docker Compose network the backend is reachable as http://backend:8080.
+ * The /api/* routes require the X-Secret header (SecretFilter); "backend:8080"
+ * is a recognised tenant domain so no explicit Host override is needed.
  */
 
 const BACKEND_HOST = `http://${process.env.VITE_SERVER_BACKEND ?? "backend"}:8080`;
@@ -20,6 +22,10 @@ const BACKEND_HEALTH_URL = `${BACKEND_HOST}/internal/actuator/health`;
 const BACKEND_API_URL = `${BACKEND_HOST}/api/users`;
 const TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 2_000;
+
+// The SecretFilter requires X-Secret on all /api/* routes.
+// The secret value is the base64-encoded shared secret (same as in utils.ts).
+const API_SECRET = Buffer.from("teambalance").toString("base64");
 
 async function pollUntilOk(
   url: string,
@@ -32,7 +38,10 @@ async function pollUntilOk(
   while (Date.now() < deadline) {
     try {
       const res = await fetch(url, {
-        headers: { Authorization: `Basic ${credentials}` },
+        headers: {
+          Authorization: `Basic ${credentials}`,
+          "X-Secret": API_SECRET,
+        },
         signal: AbortSignal.timeout(3_000),
       });
       if (res.ok) {

--- a/e2e/src/playwright/tests/auth.setup.ts
+++ b/e2e/src/playwright/tests/auth.setup.ts
@@ -20,4 +20,14 @@ setup("authenticate", async ({ page }) => {
   // End of authentication steps.
   console.log(`Storing authFile in ${authFile}`);
   await page.context().storageState({ path: authFile });
+
+  // One-time page-readiness check: reload using the stored auth state and
+  // confirm the Overview renders.  This closes the race where the auth file
+  // is written while the backend is still warming up — if the page fails to
+  // render here, the setup step fails fast rather than every test timing out.
+  await page.goto(HOST);
+  await page
+    .getByText("Aanstaande trainingen")
+    .waitFor({ state: "visible", timeout: 90_000 });
+  console.log("[auth-setup] Overview page rendered with stored auth state ✓");
 });

--- a/e2e/src/playwright/tests/crud-matches.spec.ts
+++ b/e2e/src/playwright/tests/crud-matches.spec.ts
@@ -20,7 +20,6 @@ const TEST_USER_NAME = "admin";
 test.describe("Matches", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(HOST);
-    await page.getByText("Aanstaande trainingen").waitFor({ state: "visible" });
   });
 
   test("CRUD normal match", async ({ page }) => {

--- a/e2e/src/playwright/tests/crud-misc-events.spec.ts
+++ b/e2e/src/playwright/tests/crud-misc-events.spec.ts
@@ -11,7 +11,6 @@ test.describe("Misc events", () => {
   test.beforeEach(async ({ page }) => {
     // Go to the starting url before each test.
     await page.goto(HOST);
-    await page.getByText("Aanstaande trainingen").waitFor({ state: "visible" });
   });
 
   test("can create a miscellaneous event", async ({ page }) => {

--- a/e2e/src/playwright/tests/crud-training.spec.ts
+++ b/e2e/src/playwright/tests/crud-training.spec.ts
@@ -19,7 +19,6 @@ test.describe("Training ", () => {
   test.beforeEach(async ({ page }) => {
     // Go to the starting url before each test.
     await page.goto(HOST);
-    await page.getByText("Aanstaande trainingen").waitFor({ state: "visible" });
   });
 
   test("CRUD normal training", async ({ page }) => {

--- a/e2e/src/playwright/tests/login.spec.ts
+++ b/e2e/src/playwright/tests/login.spec.ts
@@ -5,7 +5,6 @@ test.describe("login/logout functionality", () => {
   test.beforeEach(async ({ page }) => {
     // Go to the starting url before each test.
     await page.goto(HOST);
-    await page.getByText("Aanstaande trainingen").waitFor({ state: "visible" });
   });
 
   test("Login", async ({ page }) => {

--- a/e2e/src/playwright/tests/previous-events.spec.ts
+++ b/e2e/src/playwright/tests/previous-events.spec.ts
@@ -5,7 +5,6 @@ import { v4 as uuid } from "uuid";
 
 test("Validate previous events can be shown", async ({ page, request }) => {
   await page.goto(HOST);
-  await page.getByText("Aanstaande trainingen").waitFor({ state: "visible" });
   await page.getByRole("button", { name: "Admin dingen" }).click();
 
   // Use a unique comment so we can find THIS specific past event later,


### PR DESCRIPTION
## Summary
Implements Fix 1+2+3 from the e2e-flakiness diagnosis to stop the intermittent ~47min timeout that gates every merge.

- **Fix 1** — `gcp.yml` E2E step now captures backend logs too and uses `;` so `exit 1` always runs (was `&&`, masking the real failure).
- **Fix 2** — Playwright global-setup polls an authenticated API route (`/api/users`) after the actuator health check, closing the "actuator healthy but `/api` not ready" race on slow CI runners.
- **Fix 3** — the one-time "Aanstaande trainingen" page-render check runs once in `auth.setup.ts` (global-setup runs before auth, so stored state isn't available there); removed the redundant per-test `beforeEach` waits.

## Testing
- tsc/lint clean, YAML valid; reviewer pass. CI will validate the e2e run end-to-end.

🤖 Generated by TeamBalance Orchestrate System

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end readiness checks with staged backend polling and shared timeouts
  * Removed redundant post-navigation waits across multiple test suites to speed execution
  * Authentication setup now verifies the overview page renders after storing auth state

* **Bug Fixes**
  * CI E2E workflow now includes backend logs on failure and fails immediately when errors occur
<!-- end of auto-generated comment: release notes by coderabbit.ai -->